### PR TITLE
run-proofs: make run-proofs work for push and PR

### DIFF
--- a/run-proofs/steps.sh
+++ b/run-proofs/steps.sh
@@ -17,7 +17,12 @@ else
   echo "Testing l4v"
 fi
 
-fetch-pr.sh
+if [ ! -z ${GITHUB_BASE_REF+x} ]
+then
+  fetch-pr.sh
+else
+  fetch-branch.sh
+fi
 cd ..
 
 # GitHub sets its own HOME, but we have .isabelle data pre-installed in the

--- a/scripts/fetch-branch.sh
+++ b/scripts/fetch-branch.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Fetches the branch in ${GITHUB_REF} into a repo manifest checkout
+
+# Assumes a repo manifest checkout, and current working dir in the repo
+# to fetch the branch for.
+
+URL="https://github.com/${GITHUB_REPOSITORY}.git"
+
+echo "Fetching ${GITHUB_REF} from ${PR_URL}"
+git fetch -q --depth 1 ${PR_URL} ${GITHUB_REF}:${GITHUB_REF}
+git checkout -q ${GITHUB_REF}


### PR DESCRIPTION
pushes to `master` etc don't have a `$GITHUB_BASE_REF`