### PR TITLE
Add action for doing a stand-alone kernel compile on seL4 PRs

### DIFF
--- a/standalone-kernel/Dockerfile
+++ b/standalone-kernel/Dockerfile
@@ -1,0 +1,9 @@
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+FROM trustworthysystems/sel4-riscv:latest
+
+COPY compile_kernel.sh /compile_kernel.sh
+
+ENTRYPOINT ["/compile_kernel.sh"]

--- a/standalone-kernel/README.md
+++ b/standalone-kernel/README.md
@@ -1,0 +1,67 @@
+<!--
+     Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Stand-alone kernel compilation
+
+This action checks whether a change to the seL4 code breaks compilation.
+It compiles the kernel as a stand-alone item on all the verified configurations
+of seL4. It is considered 'stand-alone' because it does not compile anything else,
+so there is no user-space or supporting code.
+
+If no exit codes are thrown, it means that the change was able to compile successfully.
+
+## Content
+
+The entry point is the script [`compile_kernel.sh`](compile_kernel.sh/)
+
+## Arguments
+
+### ARCH
+
+The `ARCH` input is the architecture tag that selects the configuration to be compiled.
+Valid values are `ARM`, `ARM_HYP`, `RISCV64`, `X64`.
+
+### COMPILER
+
+The `COMPILER` input is the the choice of which compiler suite is to be used.
+Valid values are `gcc`, `llvm`.
+Note that not all `ARCH`s support all compilers.
+
+### PYTHON
+
+The `PYTHON` input is the the choice of which version of Python should be used during
+compilation.
+Valid values are `py2`, `py3`.
+
+They are best used in a matrix to run the test for all architectures
+concurrently.
+
+## Example
+
+Put this into a `.github/workflows/` yaml file, e.g. `stand-alone-compile.yml`:
+
+```yaml
+standalone_kernel:
+    name: Compile kernel
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ARM, ARM_HYP, RISCV64, X64]
+        compiler: [gcc, llvm]
+        python: [py2, py3]
+        exclude:
+          # llvm RISCV64 compilation is not currently supported
+          - arch: RISCV64
+            compiler: llvm
+    steps:
+    - uses: actions/checkout@v2
+    - uses: seL4/ci-actions/standalone-kernel@master
+      with:
+        ARCH: ${{ matrix.arch }}
+        COMPILER: ${{ matrix.compiler }}
+        PYTHON: ${{ matrix.python }}
+```

--- a/standalone-kernel/action.yml
+++ b/standalone-kernel/action.yml
@@ -1,0 +1,31 @@
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: 'Compile standalone kernel'
+description: |
+  Attempts to compile the verified configurations of the stand-alone
+  seL4 kernel.
+author: Luke Mondy <luke.mondy@data61.csiro.au>
+
+inputs:
+  ARCH:
+    description: 'Architecture to test. One of ARM, ARM_HYP, RISCV64, X64'
+    required: true
+
+  COMPILER:
+    description: 'Which compiler suite to use. One of gcc, llvm'
+    required: true
+
+  PYTHON:
+    description: 'Which version of Python to use. One of py2, py3'
+    required: true
+
+  action_name:
+    description: 'internal -- do not use'
+    required: false
+    default: 'standalone-kernel'
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'


### PR DESCRIPTION
Add action for doing a stand-alone kernel compile on seL4 PRs.
This matches our current standalone kernel building on Bamboo

You can see the example output on my fork's PR: https://github.com/LukeMondy/seL4/pull/1/checks?check_run_id=969935068