### PR TITLE
run-proof: more robust check for GITHUB_BASE_REF

### DIFF
--- a/run-proofs/steps.sh
+++ b/run-proofs/steps.sh
@@ -17,11 +17,11 @@ else
   echo "Testing l4v"
 fi
 
-if [ ! -z ${GITHUB_BASE_REF+x} ]
+if [ -z ${GITHUB_BASE_REF} ]
 then
-  fetch-pr.sh
-else
   fetch-branch.sh
+else
+  fetch-pr.sh
 fi
 cd ..
 


### PR DESCRIPTION
Also fetch from the branch (instead of PR) if `GITHUB_BASE_REF` is set, but empty.
