### PR TITLE
explicitly use python3

### DIFF
--- a/bashisms/steps.sh
+++ b/bashisms/steps.sh
@@ -13,7 +13,7 @@ echo "::group::Setting up"
 install-python.sh
 
 echo "Installing seL4 python deps"
-pip install -q sel4-deps
+pip3 install -q sel4-deps
 
 echo "Installing devscripts"
 sudo apt-get install -qq devscripts > /dev/null

--- a/gitlint/steps.sh
+++ b/gitlint/steps.sh
@@ -12,7 +12,7 @@ echo "::group::Setting up"
 install-python.sh
 
 echo "Installing gitlint tool"
-pip install -q gitlint
+pip3 install -q gitlint
 
 checkout.sh
 # fetch pull request base

--- a/scripts/install-python.sh
+++ b/scripts/install-python.sh
@@ -8,3 +8,4 @@
 
 echo "Installing python 3.7"
 sudo apt-get install -qq python3.7 > /dev/null
+pip3 install -q --upgrade pip setuptools wheel

--- a/style/steps.sh
+++ b/style/steps.sh
@@ -10,7 +10,7 @@ echo "::group::Setting up"
 install-python.sh
 
 echo "Installing seL4 python deps"
-pip install -q sel4-deps
+pip3 install -q sel4-deps
 
 echo "Installing astyle"
 sudo apt-get install -qq astyle > /dev/null


### PR DESCRIPTION
Some tests were failing because something in the background environment changed and the scripts were picking up a python2 from somewhere.
    