### PR TITLE
thylint: only report on lines in diff

### DIFF
--- a/scripts/install-python.sh
+++ b/scripts/install-python.sh
@@ -8,5 +8,8 @@
 
 echo "Installing python 3.7"
 sudo apt-get install -qq python3.7 > /dev/null
-sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
+sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1
+sudo update-alternatives --config python3
+python3 --version
 pip3 install -q --upgrade pip setuptools wheel

--- a/thylint/steps.sh
+++ b/thylint/steps.sh
@@ -31,4 +31,4 @@ echo "Checking the following files:"
 echo "$(git diff --name-only ${GITHUB_BASE_REF} test-revision)"
 echo
 git diff -z --name-only ${GITHUB_BASE_REF} test-revision | xargs -0 \
-  "$DIR/thylint.py" $DISABLE --json
+  "$DIR/thylint.py" $DISABLE --json --diff-only ${GITHUB_BASE_REF}..test-revision


### PR DESCRIPTION
This PR adds an option to thylint to only report on lines that are mentioned in the diff of a pull request (in added or changed lines).