### PR TITLE
style: produce predictable paths

### DIFF
--- a/style/steps.sh
+++ b/style/steps.sh
@@ -34,7 +34,7 @@ then
     ${SEL4_TOOLS}/misc/style.sh
 else
   # not running in pull request
-  ${SEL4_TOOLS}/misc/style-all.sh
+  ${SEL4_TOOLS}/misc/style-all.sh .
 fi
 
 [ -z "$(git status -uno --porcelain)" ] \


### PR DESCRIPTION
Make sure `find` produces relative, not absolute paths.

Related to seL4/camkes-tool#42 and should fix the issue when the corresponding sel4_tools PR is out.