### PR TITLE
Fetch checks based on SHA

### DIFF
--- a/pr-queue/index.js
+++ b/pr-queue/index.js
@@ -85,7 +85,7 @@ async function is_passing(octokit, pr) {
     const check_list = await octokit.checks.listForRef({
       owner: repo_owner(),
       repo: repo_name(),
-      ref: pr.head.ref,
+      ref: pr.head.sha,
       status: "completed",
     });
     const checks = check_list.data.check_runs;


### PR DESCRIPTION
The checks are associated with the target repository, but the branch
name doesn't exist in the target so we need to use the SHA to find the
checks instead.

Signed-off-by: Curtis Millar <curtis.millar@data61.csiro.au>