### PR TITLE
Fix link check

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: seL4/ci-actions/link-check@master
         with:
-          exclude: '*/node_modules/*'
+          exclude: '/node_modules/'
 
   style:
     name: Style

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: seL4/ci-actions/link-check@master
         with:
-          exclude: js/node_modules
+          exclude: '*/node_modules/*'
 
   style:
     name: Style

--- a/link-check/README.md
+++ b/link-check/README.md
@@ -25,12 +25,12 @@ No arguments are required. The following are available.
 
 * `files`: List of files to check
 * `dir`: Directory to check recursively, default `.`
-* `exclude`: Regex for which files to exclude (this doesn't seem to work properly)
+* `exclude`: Regex for which files to exclude
+* `exclude_urls`: Regex for which URLs to exclude from check
 * `timeout`: Timeout for link response
 * `doc_root`: Document root for absolute links
 * `num_requests`: Maximum number of concurrent requests
 * `verbose`: Print more information if set (default unset)
-
 
 ## Example
 

--- a/link-check/action.yml
+++ b/link-check/action.yml
@@ -7,13 +7,11 @@ description: 'Check links in .md and .html files'
 author: Gerwin Klein <gerwin.klein@csiro.au>
 
 inputs:
-  files:
-    description: 'List of files to check'
   dir:
     description: 'Directory to check (recursively)'
     default: .
   exclude:
-    description: 'Regex for which files to exclude'
+    description: 'grep regex on path for which files to exclude'
   timeout:
     description: 'Timeout for link response'
   doc_root:

--- a/link-check/action.yml
+++ b/link-check/action.yml
@@ -14,6 +14,9 @@ inputs:
   exclude:
     description: 'grep regex on path for which files to exclude'
     required: false
+  exclude_urls:
+    description: 'regex which URLs to exclude'
+    required: false
   timeout:
     description: 'Timeout for link response'
     required: false

--- a/link-check/action.yml
+++ b/link-check/action.yml
@@ -10,16 +10,22 @@ inputs:
   dir:
     description: 'Directory to check (recursively)'
     default: .
+    required: false
   exclude:
     description: 'grep regex on path for which files to exclude'
+    required: false
   timeout:
     description: 'Timeout for link response'
+    required: false
   doc_root:
     description: 'Document root for absolute links'
+    required: false
   num_requests:
     description: 'Maximum number of concurrent requests'
+    required: false
   verbose:
     description: 'Print more information if set (default unset)'
+    required: false
 
 runs:
   using: 'docker'

--- a/link-check/steps.sh
+++ b/link-check/steps.sh
@@ -20,5 +20,6 @@ echo "Checking links"
   xargs -0 /liche ${INPUT_DOC_ROOT:+-d "${INPUT_DOC_ROOT}"} \
          ${INPUT_TIMEOUT:+-t "${INPUT_TIMEOUT}"} \
          ${INPUT_NUM_REQUESTS:+-c "${INPUT_NUM_REQUESTS}"} \
-         ${INPUT_VERBOSE:+-v}
+         ${INPUT_EXCLUDE_URLS:+-x "${INPUT_EXCLUDE_URLS}"}
+         ${INPUT_VERBOSE:+-v} \
 ) && echo "No broken links!"

--- a/link-check/steps.sh
+++ b/link-check/steps.sh
@@ -10,15 +10,15 @@ echo "::group::Setting up"
 checkout.sh
 echo "::endgroup::"
 
-[ -n "${INPUT_FILES}" ] && unset INPUT_DIR
+INPUT_EXCLUDE=${INPUT_EXCLUDE:-^$}
 
-echo
+echo "Checking links"
+
 (set -x; \
-  /liche ${INPUT_DOC_ROOT:+-d "${INPUT_DOC_ROOT}"} \
+  find "${INPUT_DIR}" -type f \( -name "*.md" -or -name "*.html" \) | \
+  grep -v "${INPUT_EXCLUDE}" | tr '\n' '\000' | \
+  xargs -0 /liche ${INPUT_DOC_ROOT:+-d "${INPUT_DOC_ROOT}"} \
          ${INPUT_TIMEOUT:+-t "${INPUT_TIMEOUT}"} \
          ${INPUT_NUM_REQUESTS:+-c "${INPUT_NUM_REQUESTS}"} \
-         ${INPUT_EXCLUDE:+-x "${INPUT_EXCLUDE}"} \
-         ${INPUT_VERBOSE:+-v} \
-         ${INPUT_DIR:+-r "${INPUT_DIR}"} \
-         ${INPUT_FILES:+"${INPUT_FILES}"}
+         ${INPUT_VERBOSE:+-v}
 ) && echo "No broken links!"

--- a/run-proofs/README.md
+++ b/run-proofs/README.md
@@ -9,7 +9,6 @@ This action checks out the verification manifest
 <https://github.com/seL4/verification-manifest>, updates the relevant
 repository to the pull request state, and runs the specified proof images.
 
-
 ## Arguments
 
 * `L4V_ARCH` (required): which architecture to run the proofs for. One of `ARM`, `ARM_HYP`, `RISCV64`, `X64`


### PR DESCRIPTION
actually implement an exclude option. The option used before excluded URLs, not files. We now provide both.