### PR TITLE
Docker action for building the seL4 manual

### DIFF
--- a/seL4-manual/Dockerfile
+++ b/seL4-manual/Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# The context of this Dockerfiles is the repo root (../)
+
+ARG WORKSPACE=/workspace
+
+FROM trustworthysystems/sel4
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       doxygen \
+       texlive \
+       texlive-fonts-extra \
+       texlive-latex-extra \
+    && apt-get clean autoclean \
+    && apt-get autoremove --yes \
+    && rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+COPY seL4-manual/steps.sh \
+     scripts/checkout.sh \
+     /usr/bin/
+
+WORKDIR /usr/bin
+RUN chmod a+rx checkout.sh steps.sh
+
+ARG WORKSPACE
+RUN mkdir -p ${WORKSPACE}
+WORKDIR ${WORKSPACE}
+
+ENTRYPOINT steps.sh

--- a/seL4-manual/Makefile
+++ b/seL4-manual/Makefile
@@ -1,0 +1,17 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+default: build
+
+IMG=sel4/sel4-manual:latest
+
+build:
+	docker build -t $(IMG) -f Dockerfile ..
+
+push: build
+	docker push $(IMG)
+
+test: build
+	docker run -ti --entrypoint bash -e GITHUB_REPOSITORY -e GITHUB_REF \
+	  -e GITHUB_WORKSPACE $(IMG)

--- a/seL4-manual/README.md
+++ b/seL4-manual/README.md
@@ -1,0 +1,36 @@
+<!--
+     Copyright 2021, Proofcraft Pty Ltd
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Build seL4 Manual
+
+This action builds a PDF of the seL4 reference manual from the seL4 repository.
+
+It expects to be run from push or pull-request events in that repository.
+
+## Content
+
+The entry point is the script [`steps.sh`](steps.sh/)
+
+## Arguments
+
+None
+
+## Example
+
+Put this into a `.github/workflows/` yaml file, e.g. `manual.yml`:
+
+```yaml
+name: Manual
+
+on: [pull_request]
+
+jobs:
+  manual:
+    name: Build Manual
+    runs-on: ubuntu-latest
+    steps:
+    - uses: seL4/ci-actions/manual@master
+```

--- a/seL4-manual/action.yml
+++ b/seL4-manual/action.yml
@@ -1,0 +1,18 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: 'seL4 Manual'
+description: |
+  Builds the seL4 Manual.
+author: Gerwin Klein <kleing@proofcraft.systems>
+
+inputs:
+  action_name:
+    description: 'internal -- do not use'
+    required: false
+    default: 'seL4-manual'
+
+runs:
+  using: 'docker'
+  image: 'docker://sel4/sel4-manual:latest'

--- a/seL4-manual/steps.sh
+++ b/seL4-manual/steps.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# Docker entrypoint for seL4 manual test
+
+set -e
+
+# actions:
+echo "::group::Setting up"
+checkout.sh
+echo "::endgroup::"
+
+# start test
+
+cd manual
+# set draft mode:
+sed -i '~'"s/%\\\\Drafttrue/\\\\Drafttrue/" manual.tex
+make


### PR DESCRIPTION
The action builds the PDF in draft mode.

This currently still uses its own docker image, until we have figured out whether we want latex in the base images or not.

Closes #65 