### PR TITLE
bashisms: update link

### DIFF
--- a/bashisms/README.md
+++ b/bashisms/README.md
@@ -39,6 +39,6 @@ jobs:
 ### Maintenance
 
 The `checkbashism` script in `../scripts` is directly extracted from
-<https://deb.debian.org/debian/pool/main/d/devscripts/devscripts_2.21.1.tar.xz>.
+<https://deb.debian.org/debian/pool/main/d/devscripts/devscripts_2.21.2.tar.xz>.
 Installing it via `apt-get` takes forever, because the rest of the devscripts
 has lots of dependencies.


### PR DESCRIPTION
Only the link changed, the `checkbashisms` script has remained unchanged between versions.

(This fixes the failed link check)