### PR TITLE
seL4-manual: make sure all markdown is built

### DIFF
--- a/seL4-manual/steps.sh
+++ b/seL4-manual/steps.sh
@@ -17,6 +17,7 @@ echo "::endgroup::"
 # start test
 
 cd manual
+make markdown
 # set draft mode:
 sed -i '~'"s/%\\\\Drafttrue/\\\\Drafttrue/" manual.tex
 make


### PR DESCRIPTION
This should be subsumed by the PDF build, but the Makefile doesn't
really make sure it is, so we add it explicitly.
