### PR TITLE
factor out C parser builder into own image

### DIFF
--- a/.github/workflows/deploy-cparser-builder.yml
+++ b/.github/workflows/deploy-cparser-builder.yml
@@ -1,0 +1,30 @@
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Build and push link-check docker image on changes to relevant files
+
+name: Deploy
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - 'scripts/**'
+    - 'docker/**'
+
+jobs:
+  docker:
+    name: Docker (C Parser Builder)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: docker/build-push-action@v1
+      with:
+        dockerfile: docker/cparser-builder.dockerfile
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: sel4/cparser-builder
+        tags: latest
+        add_git_labels: true

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,16 @@
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+default: build
+
+IMG=sel4/cparser-builder:latest
+
+build:
+	docker build -t $(IMG) -f cparser-builder.dockerfile ..
+
+push: build
+	docker push $(IMG)
+
+test: build
+	docker run -ti --entrypoint bash $(IMG)

--- a/docker/cparser-builder.dockerfile
+++ b/docker/cparser-builder.dockerfile
@@ -1,0 +1,41 @@
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# ---[ sel4/cparser-builder ]---
+#
+# Builder container for the l4v standalone C parser
+# see the preprocess action for an example how to use
+
+# The context of this Dockerfiles is the repo root (../)
+
+ARG WORKSPACE=/workspace
+
+FROM trustworthysystems/sel4
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       mlton \
+    && apt-get clean autoclean \
+    && apt-get autoremove --yes \
+    && rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+COPY scripts/checkout-manifest.sh /usr/bin/
+RUN chmod a+rx /usr/bin/checkout-manifest.sh
+
+ARG WORKSPACE
+RUN mkdir -p ${WORKSPACE}
+WORKDIR ${WORKSPACE}
+
+RUN checkout-manifest.sh
+
+ARG CPARSER_DIR=${WORKSPACE}/l4v/tools/c-parser
+WORKDIR ${CPARSER_DIR}
+RUN make standalone-cparser
+
+ARG CP_DEST=/c-parser/standalone-parser
+RUN mkdir -p ${CP_DEST}
+WORKDIR ${CP_DEST}
+ARG CP_SRC=${CPARSER_DIR}/standalone-parser
+RUN cp ${CP_SRC}/c-parser .
+RUN cp -r ${CP_SRC}/ARM ${CP_SRC}/ARM_HYP ${CP_SRC}/RISCV64 ${CP_SRC}/X64 .

--- a/preprocess/Dockerfile
+++ b/preprocess/Dockerfile
@@ -6,42 +6,9 @@
 
 ARG WORKSPACE=/workspace
 
-# ---[ throw-away container for building c-parser ]---
-
-FROM trustworthysystems/sel4 as builder
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-       mlton \
-    && apt-get clean autoclean \
-    && apt-get autoremove --yes \
-    && rm -rf /var/lib/{apt,dpkg,cache,log}/
-
-COPY scripts/checkout-manifest.sh /usr/bin/
-RUN chmod a+rx /usr/bin/checkout-manifest.sh
-
-ARG WORKSPACE
-RUN mkdir -p ${WORKSPACE}
-WORKDIR ${WORKSPACE}
-
-RUN checkout-manifest.sh
-
-ARG CPARSER_DIR=${WORKSPACE}/l4v/tools/c-parser
-WORKDIR ${CPARSER_DIR}
-RUN make standalone-cparser
-
-ARG CP_DEST=/c-parser/standalone-parser
-RUN mkdir -p ${CP_DEST}
-WORKDIR ${CP_DEST}
-ARG CP_SRC=${CPARSER_DIR}/standalone-parser
-RUN cp ${CP_SRC}/c-parser .
-RUN cp -r ${CP_SRC}/ARM ${CP_SRC}/ARM_HYP ${CP_SRC}/RISCV64 ${CP_SRC}/X64 .
-
-# ---[ actual preprocess test container ]---
-
 FROM trustworthysystems/sel4-riscv
 
-COPY --from=builder /c-parser /c-parser
+COPY --from=sel4/cparser-builder /c-parser /c-parser
 
 COPY preprocess/make_munge.sh \
      preprocess/test_munge.sh \


### PR DESCRIPTION
We'll need the C parser for other images as well (currently building an action for C Parser kernel runs), so this PR factors the builder out into its own image that can be referenced elsewhere.

This container is not intended to be run itself, just to be copied-out-of.