### PR TITLE
GitHub action for C parser runs

### DIFF
--- a/.github/workflows/deploy-cparser-builder.yml
+++ b/.github/workflows/deploy-cparser-builder.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-# Build and push link-check docker image on changes to relevant files
+# Build and push docker image on changes to relevant files
 
 name: Deploy
 

--- a/.github/workflows/deploy-cparser-run.yml
+++ b/.github/workflows/deploy-cparser-run.yml
@@ -1,0 +1,32 @@
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Build and push cparser-run docker image on changes to relevant files
+
+name: Deploy
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - 'scripts/**'
+    - 'docker/**'
+    - 'seL4-platforms/**'
+    - 'cparser-run/**'
+
+jobs:
+  docker:
+    name: Docker (C Parser Run)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: docker/build-push-action@v1
+      with:
+        dockerfile: cparser-run/Dockerfile
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: sel4/cparser-run
+        tags: latest
+        add_git_labels: true

--- a/cparser-run/Dockerfile
+++ b/cparser-run/Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# The context of this Dockerfiles is the repo root (../)
+
+ARG WORKSPACE=/workspace
+
+FROM trustworthysystems/sel4-riscv
+
+COPY --from=sel4/cparser-builder /c-parser /c-parser
+
+COPY cparser-run/steps.sh \
+     scripts/checkout-manifest.sh \
+     scripts/fetch-branch.sh \
+     /usr/bin/
+
+WORKDIR /usr/bin
+RUN chmod a+rx checkout-manifest.sh fetch-branch.sh steps.sh
+
+RUN mkdir /builds
+COPY cparser-run/builds.yml \
+     cparser-run/build.py \
+     seL4-platforms/platforms.yml \
+     seL4-platforms/platforms.py \
+     /builds/
+
+ARG WORKSPACE
+RUN mkdir -p ${WORKSPACE}
+WORKDIR ${WORKSPACE}
+
+ENTRYPOINT steps.sh

--- a/cparser-run/Makefile
+++ b/cparser-run/Makefile
@@ -1,0 +1,17 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+default: build
+
+IMG=sel4/cparser-run:latest
+
+build:
+	docker build -t $(IMG) -f Dockerfile ..
+
+push: build
+	docker push $(IMG)
+
+test: build
+	docker run -ti --entrypoint bash -e GITHUB_REPOSITORY -e GITHUB_REF \
+	  -e GITHUB_WORKSPACE $(IMG)

--- a/cparser-run/README.md
+++ b/cparser-run/README.md
@@ -1,0 +1,52 @@
+<!--
+     Copyright 2021, Proofcraft Pty Ltd
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# C-Parser Check for seL4
+
+This action runs the C Parser used in the proofs on the seL4 repository to check
+that the code is in the supported C subset.
+
+It does so by doing a kernel-only build from the default [sel4test-manifest][1]
+for multiple configurations, advancing the seL4 repository to the branch of the
+pull request the test is called on, and running the C parser on the preprocessed
+output of the build. The reason the test uses [sel4test-manifest][1] is to make
+sure it captures a standard development build setup.
+
+This check is syntactic only. That means, even if this check succeeds there might
+still be additional reasons why specific expressions or statements are outside
+the supported subset. But it is a good first approximation.
+
+[1]: https://github.com/seL4/sel4test-manifest
+
+## Content
+
+The entry point is the script [steps.sh][].
+
+[Build](builds.yml) and [platform](../seL4-platforms/platforms.yml)
+configurations are in the respective yaml and python files in this repository.
+The main test driver is [build.py][] in this directory.
+
+## Arguments
+
+This action currently takes no arguments. To add or modify build configurations,
+edit [builds.yml][] in this directory.
+
+## Example
+
+Put this into a `.github/workflows/` yaml file, e.g. `cparser.yml`:
+
+```yaml
+name: C Parser
+
+on: [pull_request]
+
+jobs:
+  cparser:
+    name: C Parser
+    runs-on: ubuntu-latest
+    steps:
+    - uses: seL4/ci-actions/cparser-run@master
+```

--- a/cparser-run/action.yml
+++ b/cparser-run/action.yml
@@ -1,0 +1,19 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: 'CParser Run'
+description: |
+  Runs the C Parser on pull requests for the seL4 repository for a number
+  of architectures and configurations.
+author: Gerwin Klein <gerwin.klein@proofcraft.systems>
+
+inputs:
+  action_name:
+    description: 'internal -- do not use'
+    required: false
+    default: 'cparser-run'
+
+runs:
+  using: 'docker'
+  image: 'docker://sel4/cparser-run:latest'

--- a/cparser-run/build.py
+++ b/cparser-run/build.py
@@ -1,0 +1,91 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Parse builds.yml and run l4v C Parser test on each of the build definitions.
+
+Expects seL4-platforms/ to be co-located or otherwise in the PYTHONPATH.
+"""
+
+from platforms import load_ver_builds
+
+import os
+import shutil
+import subprocess
+import sys
+
+
+def run(args: list):
+    """Echo + run command with arguments; raise exception on exit != 0"""
+
+    print("+++ " + " ".join(args))
+    print(subprocess.check_output(args, text=True, stderr=subprocess.STDOUT))
+
+
+def run_build_script(manifest_dir: str, script: list) -> bool:
+    """Run a build script in a separate build/ directory
+
+    A build script is a list of commands, which itself is a list of command and
+    arguments passed to subprocess.run().
+
+    The build stops at the first failing step (or the end) and fails if any
+    step fails.
+    """
+
+    print(f"::group::{build.name}")
+    print(f"-----------[ start test {build.name} ]-----------")
+
+    os.chdir(manifest_dir)
+
+    build_dir = 'build'
+    try:
+        shutil.rmtree(build_dir)
+    except IOError:
+        pass
+
+    os.mkdir(build_dir)
+    os.chdir(build_dir)
+
+    success = True
+    try:
+        for line in script:
+            run(line)
+    except subprocess.CalledProcessError:
+        success = False
+
+    print("SUCCESS" if success else "FAILED")
+    print(f"-----------[ end test {build.name} ]-----------\n")
+    print("::endgroup::")
+
+    return success
+
+
+def run_cparser(manifest_dir: str, build):
+    """Single run of the C Parser test, for one build definition"""
+
+    script = [
+        ["../init-build.sh"] + build.settings_args(),
+        ["ninja", "kernel_all_pp_wrapper"],
+        ["/c-parser/standalone-parser/c-parser", build.l4v_arch,
+         '--underscore_idents', 'kernel/kernel_all_pp.c'],
+    ]
+
+    return run_build_script(manifest_dir, script)
+
+
+# If called as main, run all builds from builds.yml
+if __name__ == '__main__':
+    builds = load_ver_builds(os.path.dirname(__file__) + "/builds.yml")
+
+    manifest_dir = os.getcwd()
+    successes = []
+    fails = []
+    for build in builds:
+        (successes if run_cparser(manifest_dir, build) else fails).append(build.name)
+
+    print("Successful tests: " + ", ".join(successes))
+    if fails != []:
+        print("FAILED tests: " + ", ".join(fails))
+
+    sys.exit(0 if fails == [] else 1)

--- a/cparser-run/builds.yml
+++ b/cparser-run/builds.yml
@@ -1,0 +1,64 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+---
+
+# C parser runs need:
+#   - platform
+#   - mode if platform supports more than one
+#   - l4v_arch for running the parser; only the word size is relevant for this test
+#   - any other flags such as ARM_HYP, KernelVTX, MCS
+
+builds:
+- RISCV32:
+    platform: SPIKE32
+    l4v_arch: ARM # only word size relevant for this test
+
+- RISCV64:
+    platform: SPIKE64
+    l4v_arch: RISCV64
+
+- AARCH32:
+    platform: SABRE
+    l4v_arch: ARM
+
+- AARCH64:
+    platform: TX2
+    l4v_arch: X64 # only word size relevant
+
+- AARCH32HYP:
+    platform: TK1
+    l4v_arch: ARM_HYP
+    settings:
+      ARM_HYP: "TRUE"
+
+- AARCH64HYP:
+    platform: TX2
+    l4v_arch: X64 # only word size relevant
+    settings:
+      ARM_HYP: "TRUE"
+
+- IA32:
+    platform: PC99
+    mode: 32
+    l4v_arch: ARM # only word size relevant
+
+- IA32VTX:
+    platform: PC99
+    mode: 32
+    settings:
+      KernelVTX: "TRUE"
+    l4v_arch: ARM # only word size relevant
+
+- X64:
+    platform: PC99
+    mode: 64
+    l4v_arch: X64
+
+- X64VTX:
+    platform: PC99
+    mode: 64
+    settings:
+      KernelVTX: "TRUE"
+    l4v_arch: X64

--- a/cparser-run/steps.sh
+++ b/cparser-run/steps.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Copyright 2021, Proofcfraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# Docker entrypoint for seL4 cparser test
+
+set -e
+
+echo "::group::Setting up"
+export REPO_MANIFEST="default.xml"
+export MANIFEST_URL="https://github.com/seL4/sel4test-manifest.git"
+checkout-manifest.sh
+
+REPOS="$(pwd)"
+SEL4_REPO="${REPOS}/seL4"
+
+# currently this action only works for kernel PRs
+cd kernel
+fetch-branch.sh
+cd ..
+echo "::endgroup::"
+
+# start test
+python3 /builds/build.py

--- a/seL4-platforms/README.md
+++ b/seL4-platforms/README.md
@@ -1,0 +1,28 @@
+<!--
+     Copyright 2021, Proofcraft Pty Ltd
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Platform and build definitions for seL4
+
+The file [platforms.yml][] defines a list of available architectures, modes, and
+platforms for seL4 builds, and [platforms.py][] is a Python module for parsing
+and representing these.
+
+See [platforms.yml][] for which data these definitions contains, and the
+function `validate()` in [platforms.py][] for which constraints they are
+expected to satisfy.
+
+The script [platforms.py][] will dump out the interpreted contents of the yaml
+file if invoked on the command line with
+
+```sh
+python3 platforms.py
+```
+
+It will look for the yaml file in the same directory the file `platforms.py`
+resides.
+
+There are no specific seL4 tests or GitHub actions in this directory, it just
+collects common definitions.

--- a/seL4-platforms/platforms.py
+++ b/seL4-platforms/platforms.py
@@ -1,0 +1,295 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Parse and represent platform and build definitions.
+
+This module contains two main classes, Platform and Build, which represent
+test platforms and build definitions respectively. Use VerBuild for build
+definitions with setting VERIFICATION=TRUE.
+
+The main data for both is represented in yaml files, see platforms.yml and
+(for instance) cparser-run/builds.yml for examples.
+
+The module loads platforms.yml on init, which includes available architectures,
+modes, platforms, a list of unsupported platforms, and a list of named machines.
+"""
+
+from io import StringIO
+from typing import Optional
+from pprint import pprint
+import yaml
+import os
+
+# exported names:
+__all__ = [
+    "Platform", "PlatformValidationException", "Build", "VerBuild"
+    "load_builds", "load_ver_builds",
+    "all_architectures", "all_modes", "platforms", "unsupported", "machines"
+]
+
+
+class PlatformValidationException(Exception):
+    """Raised when a platform definition contains inconsistent or incomplete yaml data"""
+    pass
+
+
+class Platform:
+    """Represents a build platform.
+
+    See platforms.yml for a list of required and optional fields.
+    """
+
+    def __init__(self, name: str, **entries: dict):
+        """Construct a Platform object from a yaml dictionary.
+
+        See platforms.yml for examples, and validate() for constraints.
+        """
+        self.name = name
+        self.smp = []
+        self.aarch_hyp = []
+        self.image_platform = None
+        self.simulation_binary = None
+        self.march = None
+        self.req = None
+        self.disabled = False
+        self.__dict__.update(entries)
+        if not self.validate():
+            raise PlatformValidationException
+
+    def validate(self) -> bool:
+        """Validate the fields of this object for type and invariants"""
+
+        def sublist(sub, container):
+            # not exactly efficient, but we are talking lists of length < 5 here:
+            if not isinstance(sub, list):
+                return False
+            for x in sub:
+                if not x in container:
+                    return False
+            return True
+
+        def mode_list(modes):
+            return sublist(modes, all_modes)
+
+        def opt_str(name):
+            return name == None or isinstance(name, str)
+
+        return isinstance(self.name, str) and \
+            self.arch in all_architectures and \
+            mode_list(self.modes) and len(self.modes) > 0 and \
+            mode_list(self.smp) and \
+            mode_list(self.aarch_hyp) and \
+            opt_str(self.image_platform) and \
+            opt_str(self.simulation_binary) and \
+            opt_str(self.march) and \
+            opt_str(self.req) and \
+            isinstance(self.disabled, bool)
+
+    def __repr__(self):
+        """Return a string representation of this object."""
+
+        # This is not quite sufficient for parsing, but good enough for debugging.
+        result = StringIO()
+        result.writelines([s+"\n" for s in [
+            "{",
+            f"    name: {self.name},",
+            f"    arch: {self.arch},",
+            f"    modes: {self.modes}",
+            f"    smp: {self.smp}",
+            f"    aarch_hyp: {self.aarch_hyp}",
+            f"    image_platform: {self.image_platform}",
+            f"    simulation_binary: {self.simulation_binary}",
+            f"    march: {self.march}",
+            f"    req: {self.req}",
+            f"    disabled: {self.disabled}",
+            "  }"
+        ]])
+        return result.getvalue()
+
+    def can_32(self) -> bool:
+        """Does the platform support 32 bit execution?"""
+        return 32 in self.modes
+
+    def can_64(self) -> bool:
+        """Does the platform support 64 bit execution?"""
+        return 64 in self.modes
+
+    def can_smp_32(self) -> bool:
+        """Does the platform support SMP in mode 32?"""
+        return 32 in self.smp
+
+    def can_smp_64(self) -> bool:
+        """Does the platform support SMP in mode 64?"""
+        return 64 in self.smp
+
+    def can_aarch_hyp_32(self) -> bool:
+        """Does the platform support ARM_HYP in mode 32?"""
+        return 32 in self.aarch_hyp
+
+    def can_aarch_hyp_64(self) -> bool:
+        """Does the platform support ARM_HYP in mode 64?"""
+        return 64 in self.aarch_hyp
+
+    def get_mode(self) -> Optional[int]:
+        """Return mode (32/64) of this platform if unique, otherwise None"""
+        if len(self.modes) == 1:
+            return self.modes[0]
+        else:
+            return None
+
+    def get_platform(self, mode: int) -> str:
+        """Return platform string, including for x86"""
+        if self.arch == "x86":
+            return {32: "ia32", 64: "x86_64"}[mode]
+        else:
+            return self.platform
+
+    def toolchain_arch_str(self) -> str:
+        """Return toolchain string for arm/riscv"""
+        return {"arm": "AARCH", "riscv": "RISCV"}.get(self.arch, "")
+
+    def cmake_toolchain_setting(self, mode: int) -> str:
+        return self.toolchain_arch_str() + str(mode)
+
+    def get_image_platform(self, mode: int) -> str:
+        return self.image_platform or self.get_platform(mode)
+
+    def get_triple(self, mode: int) -> str:
+        """Return toolchain prefix triple"""
+        return {"x86":   {32: "x86_64-linux-gnu",
+                          64: "x86_64-linux-gnu"},
+                "arm":   {32: "arm-linux-gnueabi",
+                          64: "aarch64-linux-gnu"},
+                "riscv": {32: "riscv32-linux-gnu",
+                          64: "riscv64-linux-gnu"}}[self.arch][mode]
+
+    def image_names(self, mode: int, root_task: str) -> list:
+        """Return generated image name"""
+        im_plat = self.get_image_platform(mode)
+        return {
+            'arm':   [f"images/{root_task}-image-arm-{im_plat}"],
+            'x86':   [f"images/kernel-{im_plat}-pc99",
+                      f"images/{root_task}-image-{im_plat}-pc99"],
+            'riscv': [f"images/{root_task}-image-riscv-{im_plat}"],
+        }[self.arch]
+
+
+class Build:
+    """Represents a build definition.
+
+    Currently, this is mainly a name and a platform, with mode if not determined
+    by platform, and optional build settings.
+
+    See cparser-run/builds.yml for examples.
+    """
+
+    def __init__(self, **entries):
+        """Construct a Build from yaml dictionary, with default build settings."""
+        self.mode = None
+        self.settings = {}
+        [self.name] = entries.keys()
+        attribs = entries[self.name]
+        self.__dict__.update(**attribs)
+
+        p = self.get_platform()
+        m = self.get_mode()
+        if p.arch != "x86":
+            self.settings[p.cmake_toolchain_setting(m)] = "TRUE"
+        self.settings["PLATFORM"] = p.get_platform(m)
+        # somewhat misnamed now; sets test output to parsable xml:
+        self.settings["BAMBOO"] = "TRUE"
+        self.files = p.image_names(m, "sel4test-driver")
+
+    def set_verification(self):
+        """Make this a verification build"""
+        self.settings["VERIFICATION"] = "TRUE"
+
+    def get_platform(self) -> Platform:
+        """Return the Platform object for this build definition."""
+        return platforms[self.platform]
+
+    def get_mode(self) -> Optional[int]:
+        """Return the mode (32/64) for this build; taken from platform if not defined"""
+        if not self.mode and self.get_platform().get_mode():
+            return self.get_platform().get_mode()
+        else:
+            return self.mode
+
+    def settings_args(self):
+        """Return the build settings as an argument list [-Dkey=val]"""
+        return [f"-D{key}={val}" for (key, val) in self.settings.items()]
+
+
+class VerBuild(Build):
+    """A verification build definition."""
+
+    def __init__(self, **entries):
+        """Construct a Build object and set verification to true."""
+        super().__init__(**entries)
+        self.set_verification()
+
+
+def load_yaml(file_name):
+    """Load a yaml file"""
+    return yaml.safe_load(open(file_name, 'r'))
+
+
+def yaml_builds(file_name):
+    """Return the 'builds' entry of a yaml file"""
+    return load_yaml(file_name)["builds"]
+
+
+def load_builds(file_name):
+    """Load a yaml file as a list of Build objects"""
+    return [Build(**b) for b in yaml_builds(file_name)]
+
+
+def load_ver_builds(file_name):
+    """Load a yaml file as a list of VerBuild objects"""
+    return [VerBuild(**b) for b in yaml_builds(file_name)]
+
+
+# module init:
+_yaml_platforms = load_yaml(os.path.dirname(__file__) + "/platforms.yml")
+
+all_architectures = _yaml_platforms["architectures"]
+all_modes = _yaml_platforms["modes"]
+
+platforms = {name: Platform(name, **plat)
+             for (name, plat) in _yaml_platforms["platforms"].items()}
+
+unsupported = _yaml_platforms["unsupported_platforms"]
+for p in unsupported:
+    if not platforms.get(p):
+        print(f"Warning: unknown platform '{p}' in unsupported list")
+
+machines = _yaml_platforms["machines"]
+
+# if called as main, dump info:
+if __name__ == '__main__':
+    print("\n# Architectures:")
+    pprint(all_architectures)
+
+    print("\n# Modes:")
+    pprint(all_modes)
+
+    print("\n# Platforms:")
+    pprint(platforms)
+
+    print("\n# Unsupported:")
+    pprint(unsupported)
+
+    print("\n# Machines:")
+    pprint(machines)
+
+    def sup(p: Platform) -> str:
+        return p.name + (" (unsupported)" if p.name in unsupported else "")
+
+    for arch in all_architectures:
+        print(f"\n# all {arch}:")
+        pprint([sup(p) for p in platforms.values() if p.arch == arch])
+
+    print("\n# all sim:")
+    pprint([p.name for p in platforms.values() if p.simulation_binary])

--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -1,0 +1,278 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+---
+
+# Hardware and simulation platform definitions for seL4 builds.
+
+modes: [32, 64]
+architectures: [x86, arm, riscv]
+
+# platform-key:
+#     arch: one of architectures; required
+#     modes: list of modes; non-empty; required
+#     smp: list of modes; optional (null = empty)
+#     aarch_hyp: list of modes; optional (null = empty)
+#     platform: name; required
+#     image_platform: name; optional
+#     simulation_binary: string; optional
+#     march: string; optional
+#     req: string; optional
+#     disabled: optional; (null = false)
+
+platforms:
+  SPIKE32:
+    arch: riscv
+    modes: [32]
+    platform: spike
+    simlation_binary: riscv32
+    march: rv32imac
+
+  SPIKE64:
+    arch: riscv
+    modes: [64]
+    platform: spike
+    simulation_binary: riscv64
+    march: rv64imac
+
+  HIFIVE:
+    arch: riscv
+    modes: [64]
+    platform: hifive
+    req: hifive1
+    march: rv64imac
+
+  SABRE:
+    arch: arm
+    modes: [32]
+    smp: [32]
+    platform: sabre
+    image_platform: imx6
+    req: sabre-family
+    simulation_binary: sabre
+    march: armv7a
+
+  ROCKPRO64:
+    arch: arm
+    modes: [64]
+    platform: rockpro64
+    req: rockpro64-family
+    march: armv7a
+    disabled: true
+
+  ARMVIRT:
+    arch: arm
+    modes: [64]
+    platform: qemu-arm-virt
+    simulation_binary: qemu-arm-virt
+    march: armv8a
+
+  IMX8MQ_EVK:
+    arch: arm
+    modes: [64]
+    smp: [64]
+    platform: imx8mq-evk
+    req: imx8mq-family
+    march: armv8a
+
+  IMX8MM_EVK:
+    arch: arm
+    modes: [32, 64]
+    smp: [64]
+    platform: imx8mm-evk
+    req: imx8mm-family
+    march: armv8a
+
+  KZM:
+    arch: arm
+    modes: [32]
+    platform: kzm
+    image_platform: imx31
+    req: kzm
+    simulation_binary: kzm11
+    march: armv6a
+    disabled: true
+
+  OMAP3:
+    arch: arm
+    modes: [32]
+    platform: omap3
+    req: beagle
+    march: armv7a
+
+  AM335X_BONEBLACK:
+    arch: arm
+    modes: [32]
+    platform: am335x-boneblack
+    image_platform: am335x
+    req: bboneblack
+    march: armv8a
+
+  ODROID_C2:
+    arch: arm
+    modes: [64]
+    platform: odroidc2
+    req: odroidc2
+    march: armv8a
+
+  ODROID_X:
+    arch: arm
+    modes: [32]
+    platform: exynos4
+    req: odroid
+    march: armv7a
+    disabled: true
+
+  ODROID_XU:
+    arch: arm
+    modes: [32]
+    aarch_hyp: [32]
+    platform: exynos5410
+    req: odroid-xu
+    image_platform: exynos5
+    march: armv7a
+
+  ARNDALE:
+    arch: arm
+    modes: [32]
+    platform: exynos5250
+    req: arndale
+    image_platform: exynos5
+    march: armv7a
+
+  ODROID_XU4:
+    arch: arm
+    modes: [32]
+    aarch_hyp: [32]
+    platform: exynos5422
+    req: odroid-xu4-1
+    image_platform: exynos5
+    march: armv7a
+
+  ZYNQ7000:
+    arch: arm
+    modes: [32]
+    platform: zynq7000
+    req: zc706
+    simulation_binary: zc706
+    march: armv7a
+
+  ZYNQMP:
+    arch: arm
+    modes: [64]
+    smp: [64]
+    platform: zynqmp
+    req: zcu102
+    march: armv8a
+
+  HIKEY:
+    arch: arm
+    modes: [32, 64]
+    aarch_hyp: [64]
+    platform: hikey
+    req: hikey
+    march: armv8a
+
+  TK1:
+    arch: arm
+    modes: [32]
+    aarch_hyp: [32]
+    platform: tk1
+    req: jetson
+    march: armv7a
+
+  RPI3:
+    arch: arm
+    modes: [32]
+    platform: rpi3
+    req: rpi3
+    image_platform: bcm2837
+    march: armv8a
+
+  RPI4:
+    arch: arm
+    modes: [64]
+    platform: rpi4
+    req: rpi4
+    image_platform: bcm2711
+    march: armv8a
+
+  TX1:
+    arch: arm
+    modes: [64]
+    smp: [64]
+    aarch_hyp: [64]
+    platform: tx1
+    req: jetson tx1 family
+    march: armv8a
+
+  TX2:
+    arch: arm
+    modes: [64]
+    smp: [64]
+    aarch_hyp: [64]
+    platform: tx2
+    req: tx2_family
+    march: armv8a
+
+  APQ8064:
+    arch: arm
+    modes: [32]
+    platform: apq8064
+    req: inforce
+    image_platform: inforce
+    march: armv7a
+
+  WANDQ:
+    arch: arm
+    modes: [32]
+    platform: wandq
+    image_platform: imx6
+
+  ALLWINNER20:
+    arch: arm
+    modes: [32]
+    platform: allwinner20
+
+  IMX7SABRE:
+    arch: arm
+    modes: [32]
+    platform: imx7sabre
+    req: imx7
+    image_platform: imx7
+
+  PC99:
+    arch: x86
+    modes: [32, 64]
+    smp: [32, 64]
+    platform: x86_64
+    req: x64
+    simulation_binary: x86
+    march: nehalem
+
+unsupported_platforms:
+# tx1 - scheduler accuracy fails, problem with clk rate in kernel or timestamp
+# at user level?
+- TX1
+# zynq - scheduler accuracy fails, problem with clk rate in kernel or timestamp
+# at user level?
+- ZYNQ7000
+# not ported yet
+- AM335X_BONEBLACK
+- ODROID_X
+- ZYNQMP
+- IMX8MM_EVK
+- IMX8MQ_EVK
+- ROCKPRO64
+- ODROID_XU4
+
+# named machines
+# list of { req: platform } (re-using req as name)
+machines:
+- haswell1: PC99
+- haswell2: PC99
+- haswell3: PC99
+- haswell4: PC99
+- skylake: PC99
+- sandy: PC99


### PR DESCRIPTION
Adds an action for running the verification C parser on seL4 pull requests.

- add seL4 build platform definitions + python module for accessing them
- add build definitions for parser runs + python module for them (a simple first version)
- add the action itself

The action is currently completely sequential and includes both build + the parser run. Should be equivalent to the current Bamboo job for the same.

It might make sense to add MCS variants to this, which could be run in an concurrent job, or just after of this one, but will leave that for another PR

The infrastructure for this is supposed to be the basis for `sel4test` runs later, but will likely need a bit of refactoring before it can handle all use cases of that (e.g. currently there are only build definitions, but no separate run definitions, and no programatically generated variants yet either). One step at a time..

Some of the info in platforms.yml is unused at the moment (unsupported platforms, machine names). This is mostly there to capture the data that is currently in Bamboo, so we don't need to constantly go back to those definitions. Will purge these when they actually turn out unused in the end.

(This is on top of #95, which should be merged first)

Implements #69 