### PR TITLE
upgrade docker action to v2

### DIFF
--- a/.github/workflows/deploy-cparser-builder.yml
+++ b/.github/workflows/deploy-cparser-builder.yml
@@ -19,12 +19,13 @@ jobs:
     name: Docker (C Parser Builder)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: docker/build-push-action@v1
+    - uses: docker/setup-buildx-action@v1
+    - uses: docker/login-action@v1
       with:
-        dockerfile: docker/cparser-builder.dockerfile
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: sel4/cparser-builder
-        tags: latest
-        add_git_labels: true
+    - uses: docker/build-push-action@v2
+      with:
+        push: true
+        file: docker/cparser-builder.dockerfile
+        tags: sel4/cparser-builder:latest

--- a/.github/workflows/deploy-cparser-run.yml
+++ b/.github/workflows/deploy-cparser-run.yml
@@ -21,12 +21,13 @@ jobs:
     name: Docker (C Parser Run)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: docker/build-push-action@v1
+    - uses: docker/setup-buildx-action@v1
+    - uses: docker/login-action@v1
       with:
-        dockerfile: cparser-run/Dockerfile
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: sel4/cparser-run
-        tags: latest
-        add_git_labels: true
+    - uses: docker/build-push-action@v2
+      with:
+        push: true
+        file: cparser-run/Dockerfile
+        tags: sel4/cparser-run:latest

--- a/.github/workflows/deploy-link-check.yml
+++ b/.github/workflows/deploy-link-check.yml
@@ -19,12 +19,13 @@ jobs:
     name: Docker (Link Check)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: docker/build-push-action@v1
+    - uses: docker/setup-buildx-action@v1
+    - uses: docker/login-action@v1
       with:
-        dockerfile: link-check/Dockerfile
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: sel4/link-check
-        tags: latest
-        add_git_labels: true
+    - uses: docker/build-push-action@v2
+      with:
+        push: true
+        file: link-check/Dockerfile
+        tags: sel4/link-check:latest

--- a/.github/workflows/deploy-preprocess.yml
+++ b/.github/workflows/deploy-preprocess.yml
@@ -19,12 +19,13 @@ jobs:
     name: Docker (Preprocess)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: docker/build-push-action@v1
+    - uses: docker/setup-buildx-action@v1
+    - uses: docker/login-action@v1
       with:
-        dockerfile: preprocess/Dockerfile
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: sel4/preprocess
-        tags: latest
-        add_git_labels: true
+    - uses: docker/build-push-action@v2
+      with:
+        push: true
+        file: preprocess/Dockerfile
+        tags: sel4/preprocess:latest

--- a/.github/workflows/deploy-run-proofs.yml
+++ b/.github/workflows/deploy-run-proofs.yml
@@ -19,12 +19,13 @@ jobs:
     name: Docker (Run Proofs)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: docker/build-push-action@v1
+    - uses: docker/setup-buildx-action@v1
+    - uses: docker/login-action@v1
       with:
-        dockerfile: run-proofs/Dockerfile
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: sel4/run-proofs
-        tags: latest
-        add_git_labels: true
+    - uses: docker/build-push-action@v2
+      with:
+        push: true
+        file: run-proofs/Dockerfile
+        tags: sel4/run-proofs:latest


### PR DESCRIPTION
Keeping up with the times..

The upgrade was necessary, because the old docker action had trouble with the `COPY --from image:tag` option. The new v2 action, using buildkit, seems fine with it.