### PR TITLE
action for sel4test simulations

### DIFF
--- a/.github/workflows/deploy-sel4test-sim.yml
+++ b/.github/workflows/deploy-sel4test-sim.yml
@@ -1,0 +1,32 @@
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Build and push cparser-run docker image on changes to relevant files
+
+name: Deploy
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - 'scripts/**'
+    - 'seL4-platforms/**'
+    - 'sel4test-sim/**'
+
+jobs:
+  docker:
+    name: Docker (seL4Test/Sim)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: docker/setup-buildx-action@v1
+    - uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - uses: docker/build-push-action@v2
+      with:
+        push: true
+        file: sel4test-sim/Dockerfile
+        tags: sel4/sel4test-sim:latest

--- a/cparser-run/Dockerfile
+++ b/cparser-run/Dockerfile
@@ -10,6 +10,8 @@ FROM trustworthysystems/sel4-riscv
 
 COPY --from=sel4/cparser-builder /c-parser /c-parser
 
+RUN pip3 install junitparser strip-ansi
+
 COPY cparser-run/steps.sh \
      scripts/checkout-manifest.sh \
      scripts/fetch-branch.sh \
@@ -24,6 +26,7 @@ COPY cparser-run/builds.yml \
      cparser-run/build.py \
      seL4-platforms/platforms.yml \
      seL4-platforms/platforms.py \
+     seL4-platforms/builds.py \
      /builds/
 
 ARG WORKSPACE

--- a/cparser-run/Makefile
+++ b/cparser-run/Makefile
@@ -12,6 +12,9 @@ build:
 push: build
 	docker push $(IMG)
 
+run: build
+	docker run -e GITHUB_REPOSITORY -e GITHUB_REF -e GITHUB_WORKSPACE $(IMG)
+
 test: build
 	docker run -ti --entrypoint bash -e GITHUB_REPOSITORY -e GITHUB_REF \
 	  -e GITHUB_WORKSPACE $(IMG)

--- a/cparser-run/build.py
+++ b/cparser-run/build.py
@@ -8,57 +8,11 @@ Parse builds.yml and run l4v C Parser test on each of the build definitions.
 Expects seL4-platforms/ to be co-located or otherwise in the PYTHONPATH.
 """
 
-from platforms import load_ver_builds
+from builds import run_build_script, run_builds, load_builds
+from pprint import pprint
 
 import os
-import shutil
-import subprocess
 import sys
-
-
-def run(args: list):
-    """Echo + run command with arguments; raise exception on exit != 0"""
-
-    print("+++ " + " ".join(args))
-    print(subprocess.check_output(args, text=True, stderr=subprocess.STDOUT))
-
-
-def run_build_script(manifest_dir: str, script: list) -> bool:
-    """Run a build script in a separate build/ directory
-
-    A build script is a list of commands, which itself is a list of command and
-    arguments passed to subprocess.run().
-
-    The build stops at the first failing step (or the end) and fails if any
-    step fails.
-    """
-
-    print(f"::group::{build.name}")
-    print(f"-----------[ start test {build.name} ]-----------")
-
-    os.chdir(manifest_dir)
-
-    build_dir = 'build'
-    try:
-        shutil.rmtree(build_dir)
-    except IOError:
-        pass
-
-    os.mkdir(build_dir)
-    os.chdir(build_dir)
-
-    success = True
-    try:
-        for line in script:
-            run(line)
-    except subprocess.CalledProcessError:
-        success = False
-
-    print("SUCCESS" if success else "FAILED")
-    print(f"-----------[ end test {build.name} ]-----------\n")
-    print("::endgroup::")
-
-    return success
 
 
 def run_cparser(manifest_dir: str, build):
@@ -71,21 +25,15 @@ def run_cparser(manifest_dir: str, build):
          '--underscore_idents', 'kernel/kernel_all_pp.c'],
     ]
 
-    return run_build_script(manifest_dir, script)
+    return run_build_script(manifest_dir, build.name, script)
 
 
 # If called as main, run all builds from builds.yml
 if __name__ == '__main__':
-    builds = load_ver_builds(os.path.dirname(__file__) + "/builds.yml")
+    builds = load_builds(os.path.dirname(__file__) + "/builds.yml")
 
-    manifest_dir = os.getcwd()
-    successes = []
-    fails = []
-    for build in builds:
-        (successes if run_cparser(manifest_dir, build) else fails).append(build.name)
+    if len(sys.argv) > 1 and sys.argv[1] == '--dump':
+        pprint(builds)
+        sys.exit(0)
 
-    print("Successful tests: " + ", ".join(successes))
-    if fails != []:
-        print("FAILED tests: " + ", ".join(fails))
-
-    sys.exit(0 if fails == [] else 1)
+    sys.exit(run_builds(builds, run_cparser))

--- a/cparser-run/builds.yml
+++ b/cparser-run/builds.yml
@@ -4,6 +4,11 @@
 
 ---
 
+# all of the builds are verification builds
+default:
+    settings:
+        VERIFICATION: "TRUE"
+
 # C parser runs need:
 #   - platform
 #   - mode if platform supports more than one

--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -1,0 +1,484 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Parse and represent build definitions.
+
+The Build class represents build definitions.
+
+Use `load_builds` to load a build list from a yaml file, `run_builds` to run
+them, `run_build_script` for a standard test driver frame, and
+`default_junit_results` for a standard place to leave a jUnit summary file.
+"""
+
+from platforms import ValidationException, Platform, platforms, load_yaml, mcs_unsupported
+
+from typing import Optional
+from io import StringIO
+from junitparser import JUnitXml
+from strip_ansi import strip_ansi
+
+import copy
+import os
+import shutil
+import subprocess
+import sys
+
+# exported names:
+__all__ = [
+    "Build", "load_builds", "run_builds", "run_build_script", "default_junit_results"
+]
+
+# where to expect jUnit results by default
+default_junit_results = 'results.xml'
+
+
+class Build:
+    """Represents a build definition.
+
+    Currently, this is mainly a name and a platform, with mode if not determined
+    by platform, and optional build settings.
+
+    See cparser-run/builds.yml for examples.
+    """
+
+    def __init__(self, entries: dict, default={}):
+        """Construct a Build from yaml dictionary. Accept optional default build attributes."""
+        self.mode = None
+        self.settings = {}
+        [self.name] = entries.keys()
+        attribs = copy.deepcopy(default)
+        # this potentially overwrites the default settings dict, we restore it later
+        attribs.update(entries[self.name])
+        self.__dict__.update(**attribs)
+
+        if 'settings' in default:
+            for k, v in default['settings'].items():
+                if not k in self.settings:
+                    self.settings[k] = v
+
+        p = self.get_platform()
+        m = self.get_mode()
+        if p.arch != "x86":
+            self.settings[p.cmake_toolchain_setting(m)] = "TRUE"
+        self.settings["PLATFORM"] = p.get_platform(m)
+        # somewhat misnamed now; sets test output to parsable xml:
+        self.settings["BAMBOO"] = "TRUE"
+        self.files = p.image_names(m, "sel4test-driver")
+
+    def get_platform(self) -> Platform:
+        """Return the Platform object for this build definition."""
+        return platforms[self.platform]
+
+    def get_mode(self) -> Optional[int]:
+        """Return the mode (32/64) for this build; taken from platform if not defined"""
+        if not self.mode and self.get_platform().get_mode():
+            return self.get_platform().get_mode()
+        else:
+            return self.mode
+
+    def settings_args(self):
+        """Return the build settings as an argument list [-Dkey=val]"""
+        return [f"-D{key}={val}" for (key, val) in self.settings.items()]
+
+    def set_verification(self):
+        """Make this a verification build"""
+        self.settings["VERIFICATION"] = "TRUE"
+
+    def is_verification(self) -> bool:
+        return self.settings.get("VERIFICATION") != None
+
+    def can_release(self):
+        # Bamboo excludes RELEASE for RPI3:
+        return not self.get_platform().name == 'RPI3'
+
+    def set_release(self):
+        if not self.can_release():
+            raise ValidationException("not Build.can_release()")
+        self.settings["RELEASE"] = "TRUE"
+
+    def is_release(self) -> bool:
+        return self.settings.get("RELEASE") != None
+
+    def is_debug(self) -> bool:
+        return not self.is_release() and not self.is_verification()
+
+    def can_hyp(self) -> bool:
+        # Bamboo config says no MCS for arm_hyp 64 yet, and
+        # no VTX for SMP or verification
+        return not (
+            self.get_mode() == 64 and self.get_platform().arch == 'arm' and self.is_mcs() or
+            self.get_platform().name == 'PC99' and (self.is_smp() or self.is_verification())
+        ) and (
+            self.get_platform().name == 'PC99' or
+            self.get_mode() in self.get_platform().aarch_hyp
+        )
+
+    def set_hyp(self):
+        if not self.can_hyp():
+            raise ValidationException("not Build.can_hyp()")
+
+        if self.get_mode() in self.get_platform().aarch_hyp:
+            self.settings['ARM_HYP'] = "TRUE"
+        elif self.get_platform().name == 'PC99':
+            self.settings['KernelVTX'] = "TRUE"
+        else:
+            # should be unreachable because of self.can_hyp():
+            raise ValidationException
+
+    def is_hyp(self) -> bool:
+        return self.settings.get("ARM_HYP") != None or self.settings.get("KernelVTX") != None
+
+    def can_clang(self) -> bool:
+        # clang 8 does not support riscv, and Bamboo has no clang for TX1 64:
+        return not (
+            self.get_platform().arch == 'riscv' or
+            self.get_platform().name == 'TX1' and self.get_mode() == 64
+        )
+
+    def set_clang(self):
+        if not self.can_clang():
+            raise ValidationException("not Build.can_clang()")
+        self.settings["TRIPLE"] = self.get_platform().get_triple(self.get_mode())
+
+    def is_clang(self) -> bool:
+        return self.settings.get("TRIPLE") != None
+
+    def is_gcc(self) -> bool:
+        return not self.is_clang()
+
+    def can_mcs(self) -> bool:
+        # Bamboo config says no MCS from arm_hyp 64 yet, and
+        # no MCS for debug+SMP on x86_64
+        return not (
+            self.get_platform().name in mcs_unsupported or
+            self.get_mode() == 64 and self.is_hyp() and self.get_platform().arch == 'arm' or
+            self.get_platform().name == 'PC99' and self.get_mode() == 64 and not self.is_release() and self.is_smp()
+        )
+
+    def set_mcs(self):
+        if not self.can_mcs():
+            raise ValidationException("not Build.can_mcs()")
+        self.settings['MCS'] = "TRUE"
+
+    def is_mcs(self) -> bool:
+        return self.settings.get('MCS') != None
+
+    def can_smp(self) -> bool:
+        return self.get_mode() in self.get_platform().smp
+
+    def set_smp(self) -> bool:
+        if not self.can_smp():
+            raise ValidationException("not Build.can_smp()")
+        self.settings['SMP'] = "TRUE"
+
+    def is_smp(self) -> bool:
+        return self.settings.get('SMP') != None
+
+    def validate(self):
+        if not self.get_mode():
+            raise ValidationException("Build: no unique mode")
+        if not self.get_platform():
+            raise ValidationException("Build: no platform")
+        if self.is_clang() and not self.can_clang():
+            raise ValidationException("not Build.can_clang()")
+        if self.is_mcs() and not self.can_mcs():
+            raise ValidationException("not Build.can_mcs()")
+        if self.is_smp() and not self.can_smp():
+            raise ValidationException("not Build.can_smp()")
+        if self.is_release() and not self.can_release():
+            raise ValidationException("not Build.can_release()")
+        if self.is_hyp() and not self.can_hyp():
+            raise ValidationException("not Build.can_hyp()")
+
+    def __repr__(self) -> str:
+        return \
+            f"Build('{self.name}': " '{' \
+            f"'platform': {self.platform}, 'mode': {self.get_mode()}, 'settings': {self.settings}" '})'
+
+
+def run(args: list):
+    """Echo + run command with arguments; raise exception on exit != 0"""
+
+    print("+++ " + " ".join(args))
+    # Print output as it arrives. Some of the build commands take too long to
+    # wait until all output is there. Keep stderr separate, but flush it.
+    process = subprocess.Popen(args, text=True, stdout=subprocess.PIPE,
+                               stderr=sys.stderr, bufsize=1)
+    for line in process.stdout:
+        print(line.rstrip())
+        sys.stdout.flush()
+        sys.stderr.flush()
+    ret = process.wait()
+    if not ret == 0:
+        raise subprocess.CalledProcessError(ret, args)
+
+
+def summarise_junit(file_path: str) -> bool:
+    """Parse jUnit output and show a summary.
+
+    Preprocesses input to increase the chances of getting valid XML.
+    Returns True if there were no failures or errors, raises exception
+    on IOError or XML parse errors."""
+
+    with open(file_path, 'r') as file:
+        # Skip log text before and after the XML, escape some of the test output to get valid XML
+        lines = StringIO()
+        take = False
+        for line in file:
+            if line.strip() == '<testsuite>':
+                take = True
+            if take:
+                lines.write(line.replace('<<', '&lt;&lt;'))
+            if line.strip() == "</testsuite>":
+                break
+
+        xml = JUnitXml.fromstring(strip_ansi(lines.getvalue()))
+
+        print("")
+        print("Test summary")
+        print("------------")
+        print(f"tests:    {xml.tests}")
+        print(f"skipped:  {xml.skipped}")
+        print(f"failures: {xml.failures}")
+        print(f"errors:   {xml.errors}\n")
+
+        return xml.failures == 0 and xml.errors == 0
+
+
+def run_build_script(manifest_dir: str, name: str, script: list, junit: bool = False, junit_file: str = default_junit_results) -> bool:
+    """Run a build script in a separate `build/` directory
+
+    A build script is a list of commands, which itself is a list of command and
+    arguments passed to subprocess.run().
+
+    The build stops at the first failing step (or the end) and fails if any
+    step fails.
+    """
+
+    print(f"::group::{name}")
+    print(f"-----------[ start test {name} ]-----------")
+
+    os.chdir(manifest_dir)
+
+    build_dir = 'build'
+    try:
+        shutil.rmtree(build_dir)
+    except IOError:
+        pass
+
+    os.mkdir(build_dir)
+    os.chdir(build_dir)
+
+    success = True
+    try:
+        for line in script:
+            run(line)
+    except subprocess.CalledProcessError:
+        success = False
+
+    if success and junit:
+        try:
+            success = summarise_junit(junit_file)
+        except IOError:
+            print(f"Error reading {junit_file}")
+            success = False
+        except:
+            print(f"Error parsing {junit_file}")
+            success = False
+
+    print("SUCCESS" if success else "FAILED")
+    print(f"-----------[ end test {name} ]-----------\n")
+    print("::endgroup::")
+
+    return success
+
+
+def list_mult(xs: list, ys: list) -> list:
+    """Cross product of two lists. The first list is expected to be a list of lists.
+    Returns a list of lists.
+
+    `list_mult([[a],[b]], [c,d]) == [[a,c], [a,d], [b,c], [b,d]]`
+    """
+    combinations = []
+    for x in xs:
+        for y in ys:
+            combinations.append(x + [y])
+    return combinations
+
+
+def variants(var_dict: dict) -> list:
+    """Generate the matrix (=list of lists) of all variants in a variant dict."""
+
+    keys = list(var_dict.keys())
+    if keys == []:
+        return []
+
+    all = [[(keys[0], v)] for v in var_dict[keys[0]]]
+    for k in keys[1:]:
+        all = list_mult(all, [(k, v) for v in var_dict[k]])
+
+    return all
+
+
+def variant_name(variant):
+    """Return the naming postfix for a build variant."""
+    return "_".join([str(v) for _, v in variant if v != ''])
+
+
+def get_build_for_variant(platform, variant, default={}, filter_fun=lambda x: True):
+    """Make a build definition from a supplied platform and a build variant.
+
+    Optionally takes a dict of defaults and a filter/validation function to
+    set default attributes and and build settings, and to reject specific
+    build settings combinations respectively."""
+
+    var_dict = dict(variant)
+    mode = default.get("mode") or var_dict.get("mode")
+    if mode and not mode in platform.modes:
+        return None
+    mode = mode or platform.get_mode()
+    if not mode:
+        return None
+
+    the_build = copy.deepcopy(default)
+    the_build["mode"] = mode
+    the_build["platform"] = platform.name
+    build = Build({platform.name+"_"+variant_name(variant): the_build})
+
+    try:
+        for feature, val in variant:
+            if feature == 'mcs' and val != '':
+                build.set_mcs()
+            elif feature == 'smp' and val != '':
+                build.set_smp()
+            elif feature == 'hyp' and val != '':
+                build.set_hyp()
+            elif feature == 'debug' and val == 'release':
+                build.set_release()
+            elif feature == 'debug' and val == 'verification':
+                build.set_verification()
+            elif feature == 'debug' and val not in ['debug', 'verification', 'release']:
+                print(f"Warning: ignoring unknown setting {feature}: {val}")
+                raise ValidationException
+            elif feature == 'compiler' and val == 'clang':
+                build.set_clang()
+            else:
+                pass
+        build.validate()
+    except ValidationException:
+        return None
+
+    if filter_fun(build):
+        return build
+    else:
+        return None
+
+
+def filtered(build: Build, build_filters: dict) -> Optional[Build]:
+    """Return build if build matches filter criteria, otherwise None."""
+
+    def match_dict(build, f):
+        """Return true if all criteria in the filter are true for this build."""
+        for k, v in f.items():
+            if k == 'arch':
+                if not build.get_platform().arch in v:
+                    return False
+            elif k == 'march':
+                if not build.get_platform().march in v:
+                    return False
+            elif k == 'platform':
+                if not build.get_platform().platform in v:
+                    return False
+            elif k == 'debug':
+                if not build.is_debug():
+                    return False
+            elif k == 'compiler':
+                if build.is_clang():
+                    if not 'clang' in v:
+                        return False
+                else:
+                    if not 'gcc' in v:
+                        return False
+            elif k == 'mode':
+                if build.get_mode() not in v:
+                    return False
+            elif k == 'mcs':
+                if v != '' and not build.is_mcs():
+                    return False
+            elif k == 'smp':
+                if v != '' and not build.is_smp():
+                    return False
+            elif k == 'hyp':
+                if v != '' and not build.is_hyp():
+                    return False
+            elif not vars(build.get_platform()).get(k):
+                return False
+        return True
+
+    if not build:
+        return None
+
+    if not build_filters or build_filters == []:
+        return build
+
+    for f in build_filters:
+        if match_dict(build, f):
+            return build
+
+    return None
+
+
+def load_builds(file_name: str, filter_fun=lambda x: True) -> list:
+    """Load a list of build definitions from yaml.
+
+    Applies defaults, variants, and build-filter from the yaml file.
+    Takes an optional filtering function for removing unwanted builds."""
+
+    yml = load_yaml(file_name)
+
+    default_build = yml.get("default", {})
+    build_filters = yml.get("build-filter", [])
+    all_variants = variants(yml.get("variants", {}))
+    yml_builds = yml.get("builds", [])
+
+    if yml_builds == []:
+        builds = []
+        for p in platforms.keys():
+            for v in all_variants:
+                build = filtered(get_build_for_variant(
+                    platforms[p], v, default_build, filter_fun), build_filters)
+                if build:
+                    builds.append(build)
+    else:
+        # TODO: would be nice to apply variants to base builds, not only platforms
+        if all_variants != []:
+            print("Warning: ignoring variants for explicit build list.")
+
+        builds = [Build(b, default_build) for b in yml_builds]
+
+    return builds
+
+
+def run_builds(builds: list, run_fun) -> int:
+    """Run a list of build definitions, given a test driver function.
+
+    Expects the current directory to be a manifest directory, in which
+    tests are started (usually creating `build/` directory and running there).
+
+    The driver function `run_fun` should take a directory (manifest dir)
+    and a Build, and run this build, returning true iff the build was successful.
+    """
+
+    manifest_dir = os.getcwd()
+    successes = []
+    fails = []
+    for build in builds:
+        (successes if run_fun(manifest_dir, build) else fails).append(build.name)
+
+    print("Successful tests: " + ", ".join(successes))
+    if fails != []:
+        print("FAILED tests: " + ", ".join(fails))
+
+    return 0 if fails == [] else 1

--- a/seL4-platforms/platforms.py
+++ b/seL4-platforms/platforms.py
@@ -260,10 +260,10 @@ all_modes = _yaml_platforms["modes"]
 platforms = {name: Platform(name, **plat)
              for (name, plat) in _yaml_platforms["platforms"].items()}
 
-unsupported = _yaml_platforms["unsupported_platforms"]
-for p in unsupported:
+mcs_unsupported = _yaml_platforms["mcs_unsupported_platforms"]
+for p in mcs_unsupported:
     if not platforms.get(p):
-        print(f"Warning: unknown platform '{p}' in unsupported list")
+        print(f"Warning: unknown platform '{p}' in mcs_unsupported list")
 
 machines = _yaml_platforms["machines"]
 
@@ -279,13 +279,13 @@ if __name__ == '__main__':
     pprint(platforms)
 
     print("\n# Unsupported:")
-    pprint(unsupported)
+    pprint(mcs_unsupported)
 
     print("\n# Machines:")
     pprint(machines)
 
     def sup(p: Platform) -> str:
-        return p.name + (" (unsupported)" if p.name in unsupported else "")
+        return p.name + (" (unsupported)" if p.name in mcs_unsupported else "")
 
     for arch in all_architectures:
         print(f"\n# all {arch}:")

--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -26,7 +26,7 @@ platforms:
     arch: riscv
     modes: [32]
     platform: spike
-    simlation_binary: riscv32
+    simulation_binary: riscv32
     march: rv32imac
 
   SPIKE64:
@@ -229,11 +229,15 @@ platforms:
     modes: [32]
     platform: wandq
     image_platform: imx6
+    # march: ?
+    disabled: true
 
   ALLWINNER20:
     arch: arm
     modes: [32]
     platform: allwinner20
+    # march: ?
+    disabled: true
 
   IMX7SABRE:
     arch: arm
@@ -241,6 +245,8 @@ platforms:
     platform: imx7sabre
     req: imx7
     image_platform: imx7
+    # march: ?
+    disabled: true
 
   PC99:
     arch: x86
@@ -251,7 +257,7 @@ platforms:
     simulation_binary: x86
     march: nehalem
 
-unsupported_platforms:
+mcs_unsupported_platforms:
 # tx1 - scheduler accuracy fails, problem with clk rate in kernel or timestamp
 # at user level?
 - TX1

--- a/sel4test-sim/Dockerfile
+++ b/sel4test-sim/Dockerfile
@@ -1,0 +1,34 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# The context of this Dockerfiles is the repo root (../)
+
+ARG WORKSPACE=/workspace
+
+FROM trustworthysystems/sel4-riscv
+
+RUN pip3 install junitparser strip-ansi
+
+COPY sel4test-sim/steps.sh \
+     scripts/checkout-manifest.sh \
+     scripts/fetch-branch.sh \
+     scripts/repo-util \
+     /usr/bin/
+
+WORKDIR /usr/bin
+RUN chmod a+rx checkout-manifest.sh fetch-branch.sh repo-util steps.sh
+
+RUN mkdir /builds
+COPY sel4test-sim/builds.yml \
+     sel4test-sim/build.py \
+     seL4-platforms/platforms.yml \
+     seL4-platforms/platforms.py \
+     seL4-platforms/builds.py \
+     /builds/
+
+ARG WORKSPACE
+RUN mkdir -p ${WORKSPACE}
+WORKDIR ${WORKSPACE}
+
+ENTRYPOINT steps.sh

--- a/sel4test-sim/Makefile
+++ b/sel4test-sim/Makefile
@@ -1,0 +1,23 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+default: build
+
+IMG=sel4/sel4test-sim:latest
+
+build:
+	docker build -t $(IMG) -f Dockerfile ..
+
+push: build
+	docker push $(IMG)
+
+run: build
+	docker run -e GITHUB_REPOSITORY -e GITHUB_REF \
+	  -e GITHUB_WORKSPACE -e INPUT_ARCH -e INPUT_MARCH -e INPUT_MODE \
+		-e INPUT_COMPILER -e INPUT_DEBUG $(IMG)
+
+test: build
+	docker run -ti --entrypoint bash -e GITHUB_REPOSITORY -e GITHUB_REF \
+	  -e GITHUB_WORKSPACE -e INPUT_ARCH -e INPUT_MARCH -e INPUT_MODE \
+		-e INPUT_COMPILER -e INPUT_DEBUG -v $(shell pwd):/mnt:z $(IMG)

--- a/sel4test-sim/README.md
+++ b/sel4test-sim/README.md
@@ -1,0 +1,70 @@
+<!--
+     Copyright 2021, Proofcraft Pty Ltd
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# seL4Test Simulation Runs
+
+This action builds and runs [sel4test] for the platforms that have a simulation
+binary configured. The test runs can be restricted to specific `arch`, `mode`,
+and `march` settings.
+
+It does so by doing a build from the default [sel4test-manifest] for multiple
+configurations, advancing the seL4 repository to the branch of the pull request
+the test is called on, and running `./simulate` on the output of the build.
+
+[sel4test]: https://github.com/seL4/sel4test
+[sel4test-manifest]: https://github.com/seL4/sel4test-manifest
+
+## Content
+
+The entry point is the script [steps.sh].
+
+[Build] and [platform] configurations are in the respective yaml and python
+files in this repository. See these files for config documentation.
+
+The main test driver is [build.py] in this directory.
+
+[steps.sh]: ./steps.sh
+[build.py]: ./build.py
+[platform]: ../seL4-platforms/platforms.yml
+[Build]: builds.yml
+
+## Arguments
+
+To add or modify build configurations, edit [builds.yml][Build] in this
+directory. To filter the build variants defined there for a specific run,
+use one or more of the following:
+
+- `arch`: comma separated list of architecture to filter on, e.g `arm, riscv`.
+- `march`: comma separated list of `march` flags, e.g. `armv6a, nehalem`
+- `mode`: one of `{32, 64}`
+- `compiler`: one of `{gcc, clang}`
+- `debug`: comma separated list of debug levels from `{debug, release,
+  verification}`  to filter on.
+
+## Example
+
+Put this into a `.github/workflows/` yaml file, e.g. `sel4test-sim.yml`:
+
+```yaml
+name: seL4Test/Sim
+
+on: [pull_request]
+
+jobs:
+  cparser:
+    name: Simulate
+    runs-on: ubuntu-latest
+    steps:
+    strategy:
+          matrix:
+            march: ["armv6a, armv8a", armv7a, nehalem, rv32imac, rv64imac]
+            compiler: [gcc, clang]
+    steps:
+    - uses: seL4/ci-actions/sel4test-sim@master
+      with:
+        march: ${{ matrix.march }}
+        compiler: ${{ matrix.compiler }}
+```

--- a/sel4test-sim/action.yml
+++ b/sel4test-sim/action.yml
@@ -1,0 +1,36 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: 'seL4Test/Simulation'
+description: |
+  Runs sel4test build and simulation for platforms that have a
+  simulation binary configured.
+author: Gerwin Klein <gerwin.klein@proofcraft.systems>
+
+inputs:
+  arch:
+    description: Comma separated list of architectures to filter test configs on.
+    required: false
+  march:
+    description: Comma separated list of march flags to filter test configs on.
+    required: false
+  mode:
+    description: Comma separated list of modes (32/64) to filter test configs on.
+    required: false
+  compiler:
+    description: One of `{gcc, clang} to filter test configs on`
+    required: false
+  debug:
+    description: |
+      Comma separated list of debug levels from `{debug, release, verification}`
+      to filter test configs on. required: false
+    required: false
+  action_name:
+    description: 'internal -- do not use'
+    required: false
+    default: 'sel4test-sim'
+
+runs:
+  using: 'docker'
+  image: 'docker://sel4/sel4test-sim:latest'

--- a/sel4test-sim/build.py
+++ b/sel4test-sim/build.py
@@ -1,0 +1,42 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Parse builds.yml and run sel4test build + simulation on each of the build definitions.
+
+Expects seL4-platforms/ to be co-located or otherwise in the PYTHONPATH.
+"""
+
+from builds import Build, run_build_script, run_builds, load_builds, default_junit_results
+from pprint import pprint
+
+import os
+import sys
+
+
+def run_simulation(manifest_dir: str, build: Build):
+    """Run one simulation build and test."""
+
+    results = default_junit_results
+    expect = f"\"{build.success}\""
+
+    script = [
+        ["../init-build.sh"] + build.settings_args(),
+        ["ninja"],
+        ["bash", "-c",
+         f"expect -c 'spawn ./simulate; set timeout 3000; expect {expect}' | tee {results}"]
+    ]
+
+    return run_build_script(manifest_dir, build.name, script, junit=True)
+
+
+# If called as main, run all builds from builds.yml
+if __name__ == '__main__':
+    builds = load_builds(os.path.dirname(__file__) + "/builds.yml")
+
+    if len(sys.argv) > 1 and sys.argv[1] == '--dump':
+        pprint(builds)
+        sys.exit(0)
+
+    sys.exit(run_builds(builds, run_simulation))

--- a/sel4test-sim/builds.yml
+++ b/sel4test-sim/builds.yml
@@ -35,6 +35,11 @@ variants:
 # only generate builds for platofrms that have `simulation_binary` set
 build-filter:
     - simulation_binary: true
+      arch: [arm, x86]
+    - simulation_binary: true
+      arch: [riscv]
+      # Bamboo has no "release" simulation for RISCV, and it doesn't seem to work either:
+      debug: [debug]
 
 
 # A build-filter is a list of dicts. A build passes the filter if it passes any

--- a/sel4test-sim/builds.yml
+++ b/sel4test-sim/builds.yml
@@ -1,0 +1,58 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+---
+
+# default settings for simulation runs;
+# all settings available for builds are available here
+default:
+    # end marker for sel4test
+    success: "</testsuite>"
+    # default build system settings to pass in
+    settings:
+        SIMULATION: "TRUE"
+
+# generate build variants
+
+# this file does not specify a specific build list, so will default to
+# generating build variants from all platforms, filtered by the build filter
+variants:
+    debug: [debug, release]
+    compiler: [gcc, clang]
+    mode: [32, 64]
+
+# full variant scheme:
+# variants:
+#     debug: [debug, release, verification]
+#     smp: ['', SMP]
+#     hyp: ['', hyp]
+#     mcs: ['', MCS]
+#     compiler: [gcc, clang]
+#     mode: [32, 64]
+
+
+# only generate builds for platofrms that have `simulation_binary` set
+build-filter:
+    - simulation_binary: true
+
+
+# A build-filter is a list of dicts. A build passes the filter if it passes any
+# of the dicts. A build passes a dict, if it passes all of the criteria in the
+# dict. Available criteria are all values you can set in variants and all keys
+# used in builds. A build passes a key if the key is set in the build. A build
+# passes a variant list, if the build value is set and present in the list.
+
+# Example:
+
+# build-filter:
+#      - march: [armv7a]
+#        compiler: [clang, gcc]
+#        mode: [64]
+#      - arch: [x86, riscv]
+#        compiler: [gcc]
+#        mode: [32]
+#        simulation_binary:
+
+# This will select all 64-bit armv7a builds with gcc or clang and all 32-bit x86
+# and riscv builds on gcc with simulation_binary set.

--- a/sel4test-sim/steps.sh
+++ b/sel4test-sim/steps.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Copyright 2021, Proofcfraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# Docker entrypoint for seL4 cparser test
+
+set -e
+
+echo "::group::Setting up"
+export REPO_MANIFEST="default.xml"
+export MANIFEST_URL="https://github.com/seL4/sel4test-manifest.git"
+checkout-manifest.sh
+
+REPOS="$(pwd)"
+SEL4_REPO="${REPOS}/seL4"
+
+cd $(repo-util path ${GITHUB_REPOSITORY})
+fetch-branch.sh
+cd - >/dev/null
+echo "::endgroup::"
+
+# start test
+python3 /builds/build.py


### PR DESCRIPTION
- refactors the previous platform definitions to make them more general
- uses that for the sel4test action

It's getting to a state that can be reused for generating other build combinations, but I expect some more refactoring as I go along.