### PR TITLE
repo util

### DIFF
--- a/cparser-run/Dockerfile
+++ b/cparser-run/Dockerfile
@@ -13,10 +13,11 @@ COPY --from=sel4/cparser-builder /c-parser /c-parser
 COPY cparser-run/steps.sh \
      scripts/checkout-manifest.sh \
      scripts/fetch-branch.sh \
+     scripts/repo-util \
      /usr/bin/
 
 WORKDIR /usr/bin
-RUN chmod a+rx checkout-manifest.sh fetch-branch.sh steps.sh
+RUN chmod a+rx checkout-manifest.sh fetch-branch.sh steps.sh repo-util
 
 RUN mkdir /builds
 COPY cparser-run/builds.yml \

--- a/cparser-run/steps.sh
+++ b/cparser-run/steps.sh
@@ -17,10 +17,11 @@ checkout-manifest.sh
 REPOS="$(pwd)"
 SEL4_REPO="${REPOS}/seL4"
 
-# currently this action only works for kernel PRs
-cd kernel
+cd $(repo-util path ${GITHUB_REPOSITORY})
 fetch-branch.sh
-cd ..
+cd - >/dev/null
+
+repo-util hashes
 echo "::endgroup::"
 
 # start test

--- a/preprocess/Dockerfile
+++ b/preprocess/Dockerfile
@@ -15,10 +15,11 @@ COPY preprocess/make_munge.sh \
      preprocess/steps.sh \
      scripts/checkout-manifest.sh \
      scripts/fetch-pr.sh \
+     scripts/repo-util \
      /usr/bin/
 
 WORKDIR /usr/bin
-RUN chmod a+rx make_munge.sh test_munge.sh checkout-manifest.sh steps.sh
+RUN chmod a+rx make_munge.sh test_munge.sh checkout-manifest.sh repo-util steps.sh
 
 ARG WORKSPACE
 RUN mkdir -p ${WORKSPACE}

--- a/preprocess/steps.sh
+++ b/preprocess/steps.sh
@@ -36,6 +36,8 @@ then
   cd ..
 fi
 
+repo-util hashes
+
 # provide precompiled c-parser
 cp -r /c-parser "${REPOS}/l4v/tools/"
 echo "::endgroup::"

--- a/run-proofs/Dockerfile
+++ b/run-proofs/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM trustworthysystems/l4v-riscv
 
-COPY scripts/*.sh run-proofs/steps.sh /usr/bin/
+COPY scripts/*.sh scripts/repo-util run-proofs/steps.sh /usr/bin/
 COPY run-proofs/settings /isabelle/etc/
 
 # For local testing, will be overriden by github runner

--- a/run-proofs/steps.sh
+++ b/run-proofs/steps.sh
@@ -23,14 +23,8 @@ then
   cd ..
 fi
 
-if [ ${GITHUB_REPOSITORY} != ${GITHUB_REPOSITORY%/seL4} ]
-then
-  cd seL4/
-  echo "Testing seL4"
-else
-  cd l4v/
-  echo "Testing l4v"
-fi
+cd $(repo-util path ${GITHUB_REPOSITORY})
+echo "Testing ${GITHUB_REPOSITORY}"
 
 if [ -z ${GITHUB_BASE_REF} ]
 then
@@ -38,7 +32,9 @@ then
 else
   fetch-pr.sh
 fi
-cd ..
+cd - >/dev/null
+
+repo-util hashes
 
 # GitHub sets its own HOME, but we have .isabelle data pre-installed in the
 # Docker image

--- a/scripts/repo-util
+++ b/scripts/repo-util
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+#
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Utilities for `repo`.
+
+Prints path for GITHUB_REPOSITORY and shows hashes for all manifest repos +
+manifest itself.
+
+Uses git and repo as shell processes. Hopefully a more stable interface
+than trying to mess with repo python library directly.
+"""
+
+import subprocess
+import sys
+
+usage = "repo-util [path <path> | hashes]"
+
+
+def removesuffix(string: str, suffix: str) -> str:
+    """Like .removesuffix in python 3.9"""
+    if string.endswith(suffix):
+        return string[0:-len(suffix)]
+    else:
+        return string
+
+def add_manifest(projects: dict):
+    """Add the manifest repo itself as a project to the projects dict."""
+    try:
+        path = '.repo/manifests'
+        git_cmd = f"git -C {path} config --get remote.origin.url"
+        url = subprocess.check_output(git_cmd.split(' '), text=True).rstrip()
+        repo = removesuffix(url.split('/')[-1], '.git')
+        projects[repo] = path
+    except:
+        print('Error getting manifest repo. Not a `repo` checkout?', file=sys.stderr)
+        sys.exit(1)
+
+
+def get_projects() -> dict:
+    """Create dict from repo manifest; maps repo name to path."""
+    project_dict = {}
+    add_manifest(project_dict)
+    try:
+        projects = subprocess.check_output(['repo', 'list'], text=True)
+        for line in projects.splitlines():
+            path, repo = line.split(':')
+            project_dict[removesuffix(repo.strip(),'.git')] = path.strip()
+    except:
+        print("Failed to get project list from `repo`")
+        project_dict = {}
+
+    return project_dict
+
+
+def get_hash(path: str) -> str:
+    """Get git HEAD hash of repo at path."""
+    try:
+        return subprocess.check_output(['git', '-C', path, 'rev-parse', 'HEAD'], text=True).rstrip()
+    except:
+        print('Error getting hash', file=sys.stderr)
+        return ""
+
+
+def get_name(path: str, hash: str):
+    """Get a symbolic name (if available) of hash in repo at path.
+    Return empty string if no such name."""
+    try:
+        git_cmd = f"git -C {path} name-rev --name-only --no-undefined {hash}"
+        name = subprocess.check_output(git_cmd.split(' '), text=True).rstrip()
+        return f"({name})"
+    except:
+        return ""
+
+
+def show_project_hashes(projects: dict):
+    """Print all project repos with hash and symbolic (branch/tag) names."""
+    print('Manifest summary:')
+    print('-----------------')
+    indent = max([len(repo) for repo in projects])+2 if len(projects) > 0 else 0
+    for repo, path in projects.items():
+        hash = get_hash(path)[0:8]
+        print((repo+": ").rjust(indent) + hash + " " + get_name(path, hash))
+
+
+def show_all_hashes():
+    """Print repos, hashes and symbolic (branch/tag) names of current repo manifest."""
+    show_project_hashes(get_projects())
+
+
+def path_of(gh_repo: str, projects: dict) -> str:
+    """Get the path of a given repo in projects dict.
+    Accepts GITHUB_REPOSITORY-style references like seL4/seL4 (for repo "seL4")"""
+    repo = gh_repo.split('/')[-1]
+    return projects.get(repo)
+
+
+# main program:
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print(usage)
+        sys.exit(1)
+
+    if sys.argv[1] == 'hashes' and len(sys.argv) == 2:
+        show_all_hashes()
+        sys.exit(0)
+    elif sys.argv[1] == 'path' and len(sys.argv) == 3:
+        path = path_of(sys.argv[2], get_projects())
+        if path:
+            print(path)
+            sys.exit(0)
+        else:
+            print('unknown', file=sys.stderr)
+            sys.exit(1)
+    else:
+        print(usage)
+        sys.exit(1)


### PR DESCRIPTION
Small utility to:
- get path in manifest from GITHUB_REPOSITORY
- show git hashes of all repos in a manifest checkout with symbolic names

Example:

```
$ repo-util hashes
Manifest summary:
-----------------
 sel4test-manifest: f52106a4 (default)
              seL4: ce21c249 (aos)
          musllibc: c7aa943a (remotes/seL4/sel4)
         seL4_libs: 9c0d209d (remotes/seL4/12.1.x-compatible)
sel4_projects_libs: 2e30fdeb (remotes/seL4/12.1.x-compatible)
       sel4runtime: e1c51c9b (remotes/m/master)
          sel4test: 5d607ee8 (remotes/m/master)
         util_libs: 5f6cec55 (remotes/seL4/12.1.x-compatible)
            nanopb: 847ac296 (tags/0.4.0~104)
           opensbi: a98258d0 (tags/v0.8^0)
        seL4_tools: c09dea9a (remotes/seL4/12.1.x-compatible)
```

and

```
$ repo-util path seL4/seL4
kernel
```
