### PR TITLE
make repo-util case insensitive

### DIFF
--- a/scripts/checkout-manifest.sh
+++ b/scripts/checkout-manifest.sh
@@ -24,7 +24,7 @@ git config user.email > /dev/null || \
 git config color.ui > /dev/null || \
   git config --global color.ui false
 
-echo "Starting repo checkout.."
+echo "Starting repo checkout on branch ${REPO_BRANCH} with manifest ${REPO_MANIFEST}:"
 
 $REPO init --depth ${REPO_DEPTH} -m ${REPO_MANIFEST} -b ${REPO_BRANCH} -u "${MANIFEST_URL}"
 $REPO sync

--- a/scripts/repo-util
+++ b/scripts/repo-util
@@ -12,6 +12,10 @@ manifest itself.
 
 Uses git and repo as shell processes. Hopefully a more stable interface
 than trying to mess with repo python library directly.
+
+Repo URLs are treated as case insensitive to line up with GitHub and Bitbucket
+behaviour. This means, keys in the `projects` dict are lower-case, but we keep
+the spelling for the name as value to reflect what is in the manifest.
 """
 
 import subprocess
@@ -34,7 +38,8 @@ def add_manifest(projects: dict):
         git_cmd = f"git -C {path} config --get remote.origin.url"
         url = subprocess.check_output(git_cmd.split(' '), text=True).rstrip()
         repo = removesuffix(url.split('/')[-1], '.git')
-        projects[repo] = path
+        # lower-case name as key to remain case insensitive; store manifest name as value
+        projects[repo.lower()] = (path, repo)
     except:
         print('Error getting manifest repo. Not a `repo` checkout?', file=sys.stderr)
         sys.exit(1)
@@ -48,7 +53,9 @@ def get_projects() -> dict:
         projects = subprocess.check_output(['repo', 'list'], text=True)
         for line in projects.splitlines():
             path, repo = line.split(':')
-            project_dict[removesuffix(repo.strip(),'.git')] = path.strip()
+            repo = removesuffix(repo.strip(),'.git')
+            # lower-case name as key to remain case insensitive; store manifest name as value
+            project_dict[repo.lower()] = (path.strip(), repo)
     except:
         print("Failed to get project list from `repo`")
         project_dict = {}
@@ -81,7 +88,7 @@ def show_project_hashes(projects: dict):
     print('Manifest summary:')
     print('-----------------')
     indent = max([len(repo) for repo in projects])+2 if len(projects) > 0 else 0
-    for repo, path in projects.items():
+    for (path, repo) in projects.values():
         hash = get_hash(path)[0:8]
         print((repo+": ").rjust(indent) + hash + " " + get_name(path, hash))
 
@@ -95,7 +102,7 @@ def path_of(gh_repo: str, projects: dict) -> str:
     """Get the path of a given repo in projects dict.
     Accepts GITHUB_REPOSITORY-style references like seL4/seL4 (for repo "seL4")"""
     repo = gh_repo.split('/')[-1]
-    return projects.get(repo)
+    return projects.get(repo.lower(), (None, None))[0]
 
 
 # main program:

--- a/sel4test-sim/steps.sh
+++ b/sel4test-sim/steps.sh
@@ -20,6 +20,8 @@ SEL4_REPO="${REPOS}/seL4"
 cd $(repo-util path ${GITHUB_REPOSITORY})
 fetch-branch.sh
 cd - >/dev/null
+
+repo-util hashes
 echo "::endgroup::"
 
 # start test


### PR DESCRIPTION
* GitHub and Bitbucket repo URLs are case insensitive, so some of the manifest project names don't necessarily line up with the full (case sensitive) repo name.
    
  This commit brings repo-util in line with that behaviour so that it returns valid paths for PR GITHUB_REPOSITORY references that might have different case.

* use repo-util in sel4testsim to print repo hashes

* add more info on what `repo` is actually pulling (branch + manifest file). These are harder to recover later and easy to print here.