### PR TITLE
Deploy cparser-builder after all

### DIFF
--- a/.github/workflows/deploy-cparser-builder.yml
+++ b/.github/workflows/deploy-cparser-builder.yml
@@ -1,0 +1,49 @@
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Build and push docker image on changes to relevant files
+
+name: Deploy
+
+# Why deploy the builder image if it is supposed to be ephemeral? Because we
+# couldn't get the docker GitHub action to refer to a local-only image, even
+# with explicit build cache. Probably solvable, but this works as well, and it
+# does build the builder only once, so it removes duplication for only mildly
+# increased complexity.
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - 'scripts/**'
+    - 'docker/**'
+    # trigger on anything the follow-on deployments might need as well:
+    - 'seL4-platforms/**'
+    - 'cparser-run/**'
+    - 'preprocess/**'
+  repository_dispatch:
+    types: [cparser-deploy]
+  workflow_dispatch:
+
+jobs:
+  docker:
+    name: Docker (C Parser Builder)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: docker/setup-buildx-action@v1
+    - uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - uses: docker/build-push-action@v2
+      with:
+        push: true
+        file: docker/cparser-builder.dockerfile
+        tags: sel4/cparser-builder:latest
+    # this triggers the deployments that build on cparser-build:
+    - uses: peter-evans/repository-dispatch@v1
+      with:
+          token: ${{ secrets.ISA_MIRROR_TOKEN }}
+          event-type: cparser-build

--- a/.github/workflows/deploy-cparser-run.yml
+++ b/.github/workflows/deploy-cparser-run.yml
@@ -7,16 +7,10 @@
 name: Deploy
 
 on:
-  push:
-    branches:
-    - master
-    paths:
-    - 'scripts/**'
-    - 'docker/**'
-    - 'seL4-platforms/**'
-    - 'cparser-run/**'
+  # the real build trigger is in deploy-cparser-builder
   repository_dispatch:
-    types: [cparser-deploy]
+    types: [cparser-build]
+  workflow_dispatch:
 
 jobs:
   docker:

--- a/.github/workflows/deploy-preprocess.yml
+++ b/.github/workflows/deploy-preprocess.yml
@@ -7,15 +7,10 @@
 name: Deploy
 
 on:
-  push:
-    branches:
-    - master
-    paths:
-    - 'scripts/**'
-    - 'docker/**'
-    - 'preprocess/**'
+  # the real build trigger is in deploy-cparser-builder
   repository_dispatch:
-    types: [cparser-deploy]
+    types: [cparser-build]
+  workflow_dispatch:
 
 jobs:
   docker:


### PR DESCRIPTION
This mostly reverts commit 467e79db9a49efda2ce2296a12ffaa48c8af0720 and deploys the cparser image after all, because it's too hard to figure out how to refer to a locally built image in the GitHub docker action.

