### PR TITLE
run proofs on AWS

### DIFF
--- a/aws-proofs/README.md
+++ b/aws-proofs/README.md
@@ -26,6 +26,7 @@ The action expects the following two environment variables to be set.
 
 - `AWS_ACCESS_KEY_ID`: AWS user with sufficient rights to start and stop instances
 - `AWS_SECRET_ACCESS_KEY`: secret access key for that user
+- `AWS_SSH`: secret ssh key for `test-runner` user on AWS instance
 
 ## Example
 

--- a/aws-proofs/README.md
+++ b/aws-proofs/README.md
@@ -1,0 +1,68 @@
+<!--
+  Copyright 2021, Proofcraft Pty Ltd
+
+  SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Run the seL4 proofs on AWS
+
+This action checks out the verification manifest from
+<https://github.com/seL4/verification-manifest>, updates the relevant repository
+to the pull request state, and runs the specified proof images on AWS. It
+automatically spins up and terminates the corresponding AWS instance.
+
+## Arguments
+
+- `L4V_ARCH` (required): which architecture to run the proofs for. One of `ARM`,
+  `ARM_HYP`, `RISCV64`, `X64`
+- `session`: which session to run (e.g. `CRefine` or `ASpec`). Runs all sessions
+  if unset.
+- `isa-branch`: which branch of the Isabelle repo (e.g. `ts-2020`, default as in manifest)
+- `manifest`: which manifest file (e.g. `devel.xml`, `mcs.xml`, `default.xml`)
+
+## Environment
+
+The action expects the following two environment variables to be set.
+
+- `AWS_ACCESS_KEY_ID`: AWS user with sufficient rights to start and stop instances
+- `AWS_SECRET_ACCESS_KEY`: secret access key for that user
+
+## Example
+
+Put this into a `.github/workflows/` yaml file, e.g. `proofs.yml`:
+
+```yaml
+name: Proofs
+
+on: [pull_request_target]
+
+jobs:
+  check:
+    name: Proofs
+    runs-on: ubuntu-latest
+    strategy:
+          fail-fast: false
+          matrix:
+            arch: [ARM, ARM_HYP, RISCV64, X64]
+    steps:
+    - uses: seL4/ci-actions/aws-proofs@master
+      with:
+        L4V_ARCH: ${{ matrix.arch }}
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_SSH: ${{ secrets.AWS_SSH }}
+```
+
+## Build
+
+To test this action locally, you need a valid AWS access key and secret. Provide
+these via the environment variables `AWS_ACCESS_KEY_ID` and
+`AWS_SECRET_ACCESS_KEY`, set the variables `GITHUB_REPOSITORY` and `GITHUB_REF`,
+as well as at least `INPUT_L4V_ARCH` (plus optionally any other `INPUT`
+variables defined in `action.yml`).
+
+After that, run `./steps.sh` from this directory, which will spin up the
+instance and start the test. If you interrupt the test, make sure to terminate
+the AWS instance manually either in the AWS console, or by running
+`post-steps.sh`.

--- a/aws-proofs/README.md
+++ b/aws-proofs/README.md
@@ -14,11 +14,20 @@ automatically spins up and terminates the corresponding AWS instance.
 ## Arguments
 
 - `L4V_ARCH` (required): which architecture to run the proofs for. One of `ARM`,
-  `ARM_HYP`, `RISCV64`, `X64`
-- `session`: which session to run (e.g. `CRefine` or `ASpec`). Runs all sessions
-  if unset.
-- `isa-branch`: which branch of the Isabelle repo (e.g. `ts-2020`, default as in manifest)
-- `manifest`: which manifest file (e.g. `devel.xml`, `mcs.xml`, `default.xml`)
+                 `ARM_HYP`, `RISCV64`, `X64`
+- `session`:     which session to run (e.g. `CRefine` or `ASpec`, or `ASpec
+                 CRefine`, i.e. a space-separated string). Runs all sessions if
+                 unset.
+- `isa-branch`:  which branch of the Isabelle repo (e.g. `ts-2020`, default as in
+                 manifest)
+- `manifest`:    which manifest file (e.g. `devel.xml`, `mcs.xml`, `default.xml`)
+- `cache_read`:  whether to read Isabelle images from cache. Default true. Set to
+                 empty string to skip.
+- `cache_write`: whether to write Isabelle images to cache. Default true. Set to
+                 empty string to skip.
+- `cache_name`:  optional custom name for image cache. Should at least contain
+                 `L4V_ARCH`. Default is distinguishes separate caches for separate
+                 values of `isa-branch`, `manifest`, and `L4V_ARCH`.
 
 ## Environment
 
@@ -42,9 +51,9 @@ jobs:
     name: Proofs
     runs-on: ubuntu-latest
     strategy:
-          fail-fast: false
-          matrix:
-            arch: [ARM, ARM_HYP, RISCV64, X64]
+      fail-fast: false
+      matrix:
+        arch: [ARM, ARM_HYP, RISCV64, X64]
     steps:
     - uses: seL4/ci-actions/aws-proofs@master
       with:

--- a/aws-proofs/action.yml
+++ b/aws-proofs/action.yml
@@ -17,6 +17,17 @@ inputs:
   isa_branch:
     description: 'Which branch/tag of the isabelle repository to use'
     required: false
+  cache_read:
+    description: 'Read Isabelle image cache from S3. Set to empty string to skip.'
+    default: 'true'
+    required: false
+  cache_write:
+    description: 'Write Isabelle image cache to S3. Set to empty string to skip.'
+    default: 'true'
+    required: false
+  cache_name:
+    description: 'Custom cache name. Should contain at least L4V_ARCH.'
+    required: false
   manifest:
     description: "Which manifest file to use (default devel.xml)"
     required: false

--- a/aws-proofs/action.yml
+++ b/aws-proofs/action.yml
@@ -1,0 +1,31 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: 'AWS Proofs'
+description: |
+  Runs the l4v proofs on AWS.
+author: Gerwin Klein <gerwin.klein@proofcfraft.systems>
+
+inputs:
+  L4V_ARCH:
+    description: 'Architecture to test. One of ARM, ARM_HYP, RISCV64, X64'
+    required: true
+  session:
+    description: 'Which proof session to run (space-separated string)'
+    required: false
+  isa_branch:
+    description: 'Which branch/tag of the isabelle repository to use'
+    required: false
+  manifest:
+    description: "Which manifest file to use (default devel.xml)"
+    required: false
+  action_name:
+    description: 'internal -- do not use'
+    required: false
+    default: 'aws-proofs'
+
+runs:
+  using: 'node12'
+  main: '../js/index.js'
+  post: '../js/post.js'

--- a/aws-proofs/post-steps.sh
+++ b/aws-proofs/post-steps.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# Always terminate AWS instance at end of action
+
+echo "::group::Terminating AWS instance"
+
+ID=$(cat instance.txt | jq -r '.Instances[0].InstanceId')
+echo "Instance ID: ${ID}"
+aws ec2 terminate-instances --instance-ids ${ID}
+
+echo "::endgroup::"

--- a/aws-proofs/run
+++ b/aws-proofs/run
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# ./run [ci-actions-branch]
+#
+# This script is the entry point on the AWS instance.
+#
+# Currently, the VM image must be updated manually if this script changes.
+#
+# It clones the ci-actions repo and runs the test driver from there. Expects to
+# be running in /home/test-runner/ as the test-runner user. Input to the test
+# driver is via environment variables as in the docker steup.
+
+# Ultimate timeout in case anything goes wrong. GH runners will time out at 6h,
+# so we give it all of that plus a few minutes:
+sudo shutdown -h +365
+
+# Set up GH action repo:
+
+ACTION_DIR=ci-actions
+
+# get specified branch of CI actions repo
+mkdir ${ACTION_DIR}
+cd ${ACTION_DIR}
+
+REPO_URL="https://github.com/seL4/ci-actions.git"
+BRANCH=${1:-master}
+
+echo "Cloning ${REPO_URL}@${BRANCH}"
+git init -q .
+git remote add origin ${REPO_URL}
+git fetch -q --no-tags --depth 1 origin refs/heads/${BRANCH}
+git checkout -q ${BRANCH}
+
+cd ..
+
+# actual test run:
+${ACTION_DIR}/aws-proofs/vm-steps.sh

--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -16,7 +16,7 @@ aws configure set default.region us-east-2
 aws configure set default.output json
 
 echo "Starting AWS instance..."
-aws ec2 run-instances --image-id ami-02c8221b1c83159b4 --count 1 \
+aws ec2 run-instances --image-id ami-02109a93a0bf86295 --count 1 \
                       --instance-type c5.4xlarge \
                       --iam-instance-profile "Name=test-runner-role" \
                       --security-group-ids sg-0491b450a86520294 \
@@ -53,6 +53,9 @@ ssh -o StrictHostKeyChecking=no test-runner@${IP} \
                export INPUT_MANIFEST=${INPUT_MANIFEST}; \
                export INPUT_ISA_BRANCH=${INPUT_ISA_BRANCH}; \
                export INPUT_SESSION=${INPUT_SESSION}; \
+               export INPUT_CACHE_NAME=${INPUT_CACHE_NAME}; \
+               export INPUT_CACHE_READ=${INPUT_CACHE_READ}; \
+               export INPUT_CACHE_WRITE=${INPUT_CACHE_WRITE}; \
                export GITHUB_REPOSITORY=${GITHUB_REPOSITORY}; \
                export GITHUB_REF=${GITHUH_REF}; \
                export GITHUB_BASE_REF=${GITHUH_BASE_REF}; \

--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -49,6 +49,4 @@ ssh -o StrictHostKeyChecking=no test-runner@${IP} \
                export GITHUB_WORKSPACE=/home/test-runner; \
                ./run ${CI_BRANCH}\""
 
-# TODO: put this into a post-action step
-echo "Terminating AWS instance ${ID}"
-aws ec2 terminate-instances --instance-ids ${ID}
+# instance termination is in post-steps.sh

--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -62,4 +62,7 @@ ssh -o StrictHostKeyChecking=no test-runner@${IP} \
                export GITHUB_WORKSPACE=/home/test-runner; \
                ./run ${CI_BRANCH}\""
 
+# leave logs on GitHub runner for later artifact upload
+scp test-runner@${IP}:logs.tar.xz .
+
 # instance termination is in post-steps.sh

--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -9,6 +9,8 @@
 # keep an active ssh session during the test so that we get live logs.
 
 echo "::group::AWS"
+aws configure set default.region us-east-2
+aws configure set default.output json
 
 echo "Starting AWS instance..."
 aws ec2 run-instances --image-id ami-0cd8b8f8a84d89a14 --count 1 \

--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -9,6 +9,9 @@
 # keep an active ssh session during the test so that we get live logs.
 
 echo "::group::AWS"
+# fail on any error
+set -e
+
 aws configure set default.region us-east-2
 aws configure set default.output json
 
@@ -32,6 +35,7 @@ IP=$(aws ec2 describe-instances --instance-ids ${ID} | \
      jq -r '.Reservations[0].Instances[0].PublicIpAddress')
 
 echo "IP address ${IP}"
+if [ -z ${IP} ]; then exit 1; fi
 
 echo "Waiting for sshd to come up"
 until nc -w5 -z ${IP} 22; do echo "."; sleep 3; done

--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -18,6 +18,7 @@ aws configure set default.output json
 echo "Starting AWS instance..."
 aws ec2 run-instances --image-id ami-02c8221b1c83159b4 --count 1 \
                       --instance-type c5.4xlarge \
+                      --iam-instance-profile "Name=test-runner-role" \
                       --security-group-ids sg-0491b450a86520294 \
                       --instance-market-options "MarketType=spot" \
                       --instance-initiated-shutdown-behavior terminate > instance.txt

--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -13,7 +13,7 @@ aws configure set default.region us-east-2
 aws configure set default.output json
 
 echo "Starting AWS instance..."
-aws ec2 run-instances --image-id ami-0cd8b8f8a84d89a14 --count 1 \
+aws ec2 run-instances --image-id ami-02c8221b1c83159b4 --count 1 \
                       --instance-type c5.4xlarge \
                       --security-group-ids sg-0491b450a86520294 \
                       --instance-market-options "MarketType=spot" \
@@ -35,6 +35,9 @@ echo "IP address ${IP}"
 
 echo "Waiting for sshd to come up"
 until nc -w5 -z ${IP} 22; do echo "."; sleep 3; done
+
+eval $(ssh-agent)
+ssh-add -q - <<< "${AWS_SSH}"
 
 echo "::endgroup::"
 

--- a/aws-proofs/vm-steps.sh
+++ b/aws-proofs/vm-steps.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# test driver inside the VM; expects to be called by "run"
+
+set -e
+
+echo "::group::Setting up"
+export PATH=/home/test-runner/ci-actions/scripts:/home/test-runner/.local/bin:/home/test-runner/.bin:$PATH
+mkdir ver
+cd ver
+
+if [ -n ${INPUT_MANIFEST} ]
+then
+  export REPO_MANIFEST="${INPUT_MANIFEST}"
+fi
+
+checkout-manifest.sh
+
+if [ -n "${INPUT_ISA_BRANCH}" ]
+then
+  cd isabelle
+  echo "Fetching ${INPUT_ISA_BRANCH} from remote \"verification\""
+  git fetch -q --depth 1 verification ${INPUT_ISA_BRANCH}
+  git checkout -q ${INPUT_ISA_BRANCH}
+  cd ..
+fi
+
+cd $(repo-util path ${GITHUB_REPOSITORY})
+echo "Testing ${GITHUB_REPOSITORY}"
+
+if [ -z ${GITHUB_BASE_REF} ]
+then
+  fetch-branch.sh
+else
+  fetch-pr.sh
+fi
+cd - >/dev/null
+
+repo-util hashes
+
+echo "Setting up Isabelle components"
+isabelle/bin/isabelle components -a
+echo "::endgroup::"
+
+export L4V_ARCH=${INPUT_L4V_ARCH}
+
+FAIL=0
+
+cd l4v
+if [ "${INPUT_SESSION}" = "CRefine" ]
+then
+  # special treatment for CRefine session to speed up seL4 code change checks
+
+  cd proof
+  make CRefine || FAIL=1
+  cd ..
+
+elif [ -n ${INPUTSESSION} ]
+then
+  ./run_tests -v ${INPUT_SESSION} || FAIL=1
+else
+  ./run_tests -v -x AutoCorresSEL4 || FAIL=1
+fi
+cd ..
+
+# shut down test VM 1min after exiting this script
+sudo shutdown -h +1
+
+exit $FAIL

--- a/aws-proofs/vm-steps.sh
+++ b/aws-proofs/vm-steps.sh
@@ -98,7 +98,12 @@ else
   echo "Skipping image cache write"
 fi
 
-# shut down test VM 1min after exiting this script
-sudo shutdown -h +1
+# bundle up logs for artifact upload outside the VM
+# xz compression does help even if there are many .gz files in this set
+cd ~/.isabelle/heaps
+tar -Jcf ~/logs.tar.xz */log/*
+
+# shut down VM 5 min after exiting (leave some time for log upload)
+sudo shutdown -h +5
 
 exit $FAIL

--- a/js/post.js
+++ b/js/post.js
@@ -1,9 +1,9 @@
 /*
- * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2021, Proofcraft Pty Ltd
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 var run = require('./run')
 
-run.run('steps.sh');
+run.run('post-steps.sh');

--- a/js/run.js
+++ b/js/run.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+const core = require('@actions/core');
+const exec = require('@actions/exec');
+
+module.exports = {
+  run: async function(steps) {
+    const action_name = core.getInput('action_name');
+    try {
+      const src_dir = __dirname;
+      const script_dir = `${src_dir}/../scripts`;
+      core.addPath(script_dir);
+      const options = { };
+      options.env = process.env;
+      options.env.SCRIPTS = `${script_dir}`;
+      core.addPath(process.env.HOME + '/.local/bin')
+      const action_dir = `${src_dir}/../${action_name}`
+      await exec.exec(`${action_dir}/${steps}`, [], options);
+    } catch (error) {
+      core.setFailed(`Action ${action_name} failed.`);
+    }
+  }
+}


### PR DESCRIPTION
This implements a GH action similar to `run-proofs` which runs the l4v proofs on AWS instead of on GitHub runners directly. This should remove the resource problems the GitHub runners presented for the proofs.

This also implements a cache for generated Isabelle images on S3.
