### PR TITLE
aws-proofs: make GH logs nicer to read

### DIFF
--- a/aws-proofs/run
+++ b/aws-proofs/run
@@ -15,6 +15,8 @@
 # be running in /home/test-runner/ as the test-runner user. Input to the test
 # driver is via environment variables as in the docker steup.
 
+echo "::group::Action setup"
+
 # Ultimate timeout in case anything goes wrong. GH runners will time out at 6h,
 # so we give it all of that plus a few minutes:
 sudo shutdown -h +365
@@ -37,6 +39,8 @@ git fetch -q --no-tags --depth 1 origin refs/heads/${BRANCH}
 git checkout -q ${BRANCH}
 
 cd ..
+
+echo "::endgroup::"
 
 # actual test run:
 ${ACTION_DIR}/aws-proofs/vm-steps.sh

--- a/aws-proofs/vm-steps.sh
+++ b/aws-proofs/vm-steps.sh
@@ -55,6 +55,7 @@ then
   CACHE_NAME="${GITHUB_REPOSITORY}-${BRANCH}-${MANIFEST}-${INPUT_L4V_ARCH}"
 fi
 
+echo "::group::Cache"
 if [ -n ${CACHE_NAME} ]
 then
   echo "Getting image cache ${CACHE_NAME}"
@@ -63,9 +64,11 @@ then
 else
   echo "Skipping image cache read"
 fi
-
+echo "::endgroup::"
 
 echo "::endgroup::"
+
+echo "::group::Proof run"
 
 export L4V_ARCH=${INPUT_L4V_ARCH}
 
@@ -88,6 +91,9 @@ else
 fi
 cd ..
 
+echo "::endgroup::"
+
+echo "::group::Cache and logs"
 if [ -n "${CACHE_NAME}" ] && [ -n "${INPUT_CACHE_WRITE}" ]
 then
   echo "Writing image cache ${CACHE_NAME}"
@@ -105,5 +111,6 @@ tar -Jcf ~/logs.tar.xz */log/*
 
 # shut down VM 5 min after exiting (leave some time for log upload)
 sudo shutdown -h +5
+echo "::endgroup::"
 
 exit $FAIL


### PR DESCRIPTION
Adding groups so that admin content is folded away.
