### PR TITLE
slightly better ssh use

### DIFF
--- a/aws-proofs/run
+++ b/aws-proofs/run
@@ -30,7 +30,7 @@ mkdir ${ACTION_DIR}
 cd ${ACTION_DIR}
 
 REPO_URL="https://github.com/seL4/ci-actions.git"
-BRANCH=${1:-master}
+BRANCH=${INPUT_CI_BRANCH:-master}
 
 echo "Cloning ${REPO_URL}@${BRANCH}"
 git init -q .

--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -16,7 +16,7 @@ aws configure set default.region us-east-2
 aws configure set default.output json
 
 echo "Starting AWS instance..."
-aws ec2 run-instances --image-id ami-02109a93a0bf86295 --count 1 \
+aws ec2 run-instances --image-id ami-0a1614a3e5ad44d6b --count 1 \
                       --instance-type c5.4xlarge \
                       --iam-instance-profile "Name=test-runner-role" \
                       --security-group-ids sg-0491b450a86520294 \


### PR DESCRIPTION
- set up host key before `ssh` (doesn't really add security, but quietens down `ssh`)
- pass env via `ssh` (needs VM sshd config update)

I couldn't find a good method to get the host key from AWS without waiting forever. A new host key is generated at boot time so that not all VMs have the same key. It is echoed on the console during boot, and you can even get the console output from AWS, but only about 3 min after boot on average, and that is too long for my impatience.

So, since no secret data is being passed to the VM and the only output we use from `ssh` is logs and overall test result, I think this is fine.