### PR TITLE
aws-proofs: option for skipping duplicated proofs

### DIFF
--- a/aws-proofs/README.md
+++ b/aws-proofs/README.md
@@ -28,6 +28,9 @@ automatically spins up and terminates the corresponding AWS instance.
 - `cache_name`:  optional custom name for image cache. Should at least contain
                  `L4V_ARCH`. Default is distinguishes separate caches for separate
                  values of `isa-branch`, `manifest`, and `L4V_ARCH`.
+- `skip_dups`:   skip duplicated proofs (default true).
+                 Set to empty string to also run proofs that are already checked
+                 in other proof sessions.
 
 ## Environment
 

--- a/aws-proofs/action.yml
+++ b/aws-proofs/action.yml
@@ -28,6 +28,10 @@ inputs:
   cache_name:
     description: 'Custom cache name. Should contain at least L4V_ARCH.'
     required: false
+  skip_dups:
+    description: 'Skip duplicate proofs. Set to empty string to run duplicate proofs'
+    default: "1"
+    required: false
   manifest:
     description: "Which manifest file to use (default devel.xml)"
     required: false

--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -63,6 +63,7 @@ ssh -o StrictHostKeyChecking=no test-runner@${IP} \
                export INPUT_CACHE_NAME=${INPUT_CACHE_NAME}; \
                export INPUT_CACHE_READ=${INPUT_CACHE_READ}; \
                export INPUT_CACHE_WRITE=${INPUT_CACHE_WRITE}; \
+               export INPUT_SKIP_DUPS=${INPUT_SKIP_DUPS}; \
                export GITHUB_REPOSITORY=${GITHUB_REPOSITORY}; \
                export GITHUB_REF=${GH_REF}; \
                export GITHUB_BASE_REF=${GITHUH_BASE_REF}; \

--- a/aws-proofs/vm-steps.sh
+++ b/aws-proofs/vm-steps.sh
@@ -71,6 +71,7 @@ echo "::endgroup::"
 echo "::group::Proof run"
 
 export L4V_ARCH=${INPUT_L4V_ARCH}
+export SKIP_DUPLICATED_PROOFS=${INPUT_SKIP_DUPS}
 
 FAIL=0
 


### PR DESCRIPTION
Set SKIP_DUPLICATED_PROOFS by default, but provide option to turn it off.
