### PR TITLE
action for seL4 tutorial tests

### DIFF
--- a/cparser-run/Dockerfile
+++ b/cparser-run/Dockerfile
@@ -10,7 +10,7 @@ FROM trustworthysystems/sel4-riscv
 
 COPY --from=sel4/cparser-builder /c-parser /c-parser
 
-RUN pip3 install junitparser strip-ansi
+RUN pip3 install junitparser
 
 COPY cparser-run/steps.sh \
      scripts/checkout-manifest.sh \

--- a/cparser-run/steps.sh
+++ b/cparser-run/steps.sh
@@ -14,9 +14,6 @@ export REPO_MANIFEST="default.xml"
 export MANIFEST_URL="https://github.com/seL4/sel4test-manifest.git"
 checkout-manifest.sh
 
-REPOS="$(pwd)"
-SEL4_REPO="${REPOS}/seL4"
-
 cd $(repo-util path ${GITHUB_REPOSITORY})
 fetch-branch.sh
 cd - >/dev/null

--- a/scripts/repo-util
+++ b/scripts/repo-util
@@ -31,6 +31,15 @@ def removesuffix(string: str, suffix: str) -> str:
     else:
         return string
 
+
+def removeprefix(string: str, prefix: str) -> str:
+    """Like .removeprefix in python 3.9"""
+    if string.startswith(prefix):
+        return string[len(prefix):]
+    else:
+        return string
+
+
 def add_manifest(projects: dict):
     """Add the manifest repo itself as a project to the projects dict."""
     try:
@@ -53,7 +62,7 @@ def get_projects() -> dict:
         projects = subprocess.check_output(['repo', 'list'], text=True)
         for line in projects.splitlines():
             path, repo = line.split(':')
-            repo = removesuffix(repo.strip(),'.git')
+            repo = removesuffix(repo.strip(), '.git')
             # lower-case name as key to remain case insensitive; store manifest name as value
             project_dict[repo.lower()] = (path.strip(), repo)
     except:
@@ -72,13 +81,34 @@ def get_hash(path: str) -> str:
         return ""
 
 
+# give full line a decent chance to fit into 100 chars
+title_len = 46
+
+
+def get_title(path: str, hash: str) -> str:
+    """Return commit title line for hash."""
+    try:
+        title = subprocess.check_output(['git', '-C', path, 'log', '--format=%s',
+                                         '-n', '1', hash], text=True).rstrip()
+        if len(title) > title_len:
+            title = title[0:title_len-2]+".."
+        return title
+    except:
+        print('Error getting title', file=sys.stderr)
+        return ""
+
+
 def get_name(path: str, hash: str):
     """Get a symbolic name (if available) of hash in repo at path.
     Return empty string if no such name."""
     try:
-        git_cmd = f"git -C {path} name-rev --name-only --no-undefined {hash}"
-        name = subprocess.check_output(git_cmd.split(' '), text=True).rstrip()
-        return f"({name})"
+        git_cmd = f"git -C {path} name-rev --name-only --no-undefined".split(' ')
+        # exclude ref names that don't give much info:
+        cmd = git_cmd + ["--exclude", "m/*",      # put in by repo, seems to be always "master"
+                         "--exclude", "default",  # manifest is always on "default"
+                         hash]
+        name = subprocess.check_output(cmd, text=True, stderr=subprocess.PIPE).rstrip()
+        return f"({removeprefix(name,'remotes/')})"
     except:
         return ""
 
@@ -90,7 +120,10 @@ def show_project_hashes(projects: dict):
     indent = max([len(repo) for repo in projects])+2 if len(projects) > 0 else 0
     for (path, repo) in projects.values():
         hash = get_hash(path)[0:8]
-        print((repo+": ").rjust(indent) + hash + " " + get_name(path, hash))
+        print((repo+": ").rjust(indent) +
+              hash + " " +
+              get_title(path, hash).ljust(title_len+1) +
+              get_name(path, hash))
 
 
 def show_all_hashes():

--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -414,7 +414,7 @@ def get_env_filters() -> list:
     def to_list(string: str) -> list:
         return [s.strip() for s in string.split(',')]
 
-    keys = ['march', 'arch', 'mode', 'compiler', 'debug', 'platform']
+    keys = ['march', 'arch', 'mode', 'compiler', 'debug', 'platform', 'name', 'app']
     filter = {k: to_list(get(k)) for k in keys if get(k)}
     # 'mode' expects integers:
     if 'mode' in filter:
@@ -425,7 +425,7 @@ def get_env_filters() -> list:
 def filtered(build: Build, build_filters: dict) -> Optional[Build]:
     """Return build if build matches filter criteria, otherwise None."""
 
-    def match_dict(build, f):
+    def match_dict(build: Build, f):
         """Return true if all criteria in the filter are true for this build."""
         for k, v in f.items():
             if k == 'arch':
@@ -462,6 +462,12 @@ def filtered(build: Build, build_filters: dict) -> Optional[Build]:
                     return False
             elif k == 'hyp':
                 if v != '' and not build.is_hyp():
+                    return False
+            elif k == 'name':
+                if not build.name in v:
+                    return False
+            elif k == 'app':
+                if not build.app in v:
                     return False
             elif not vars(build.get_platform()).get(k):
                 return False

--- a/sel4test-hw/Dockerfile
+++ b/sel4test-hw/Dockerfile
@@ -8,7 +8,7 @@ ARG WORKSPACE=/workspace
 
 FROM trustworthysystems/sel4-riscv
 
-RUN pip3 install junitparser strip-ansi
+RUN pip3 install junitparser
 
 COPY sel4test-hw/steps.sh \
      scripts/checkout-manifest.sh \

--- a/sel4test-hw/steps.sh
+++ b/sel4test-hw/steps.sh
@@ -14,9 +14,6 @@ export REPO_MANIFEST="default.xml"
 export MANIFEST_URL="https://github.com/seL4/sel4test-manifest.git"
 checkout-manifest.sh
 
-REPOS="$(pwd)"
-SEL4_REPO="${REPOS}/seL4"
-
 cd $(repo-util path ${GITHUB_REPOSITORY})
 fetch-branch.sh
 cd - >/dev/null

--- a/sel4test-sim/Dockerfile
+++ b/sel4test-sim/Dockerfile
@@ -8,7 +8,7 @@ ARG WORKSPACE=/workspace
 
 FROM trustworthysystems/sel4-riscv
 
-RUN pip3 install junitparser strip-ansi
+RUN pip3 install junitparser
 
 COPY sel4test-sim/steps.sh \
      scripts/checkout-manifest.sh \

--- a/sel4test-sim/build.py
+++ b/sel4test-sim/build.py
@@ -8,7 +8,7 @@ Parse builds.yml and run sel4test build + simulation on each of the build defini
 Expects seL4-platforms/ to be co-located or otherwise in the PYTHONPATH.
 """
 
-from builds import Build, run_build_script, run_builds, load_builds, default_junit_results
+from builds import Build, run_build_script, run_builds, load_builds, junit_results, sanitise_junit
 from pprint import pprint
 
 import os
@@ -18,14 +18,13 @@ import sys
 def run_simulation(manifest_dir: str, build: Build):
     """Run one simulation build and test."""
 
-    results = default_junit_results
     expect = f"\"{build.success}\""
 
     script = [
         ["../init-build.sh"] + build.settings_args(),
         ["ninja"],
         ["bash", "-c",
-         f"expect -c 'spawn ./simulate; set timeout 3000; expect {expect}' | tee {results}"]
+         f"expect -c 'spawn ./simulate; set timeout 3000; expect {expect}' | tee {junit_results}"]
     ]
 
     return run_build_script(manifest_dir, build.name, script, junit=True)

--- a/sel4test-sim/steps.sh
+++ b/sel4test-sim/steps.sh
@@ -14,9 +14,6 @@ export REPO_MANIFEST="default.xml"
 export MANIFEST_URL="https://github.com/seL4/sel4test-manifest.git"
 checkout-manifest.sh
 
-REPOS="$(pwd)"
-SEL4_REPO="${REPOS}/seL4"
-
 cd $(repo-util path ${GITHUB_REPOSITORY})
 fetch-branch.sh
 cd - >/dev/null

--- a/tutorials/Dockerfile
+++ b/tutorials/Dockerfile
@@ -1,0 +1,36 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# The context of this Dockerfiles is the repo root (../)
+
+ARG WORKSPACE=/workspace
+
+FROM trustworthysystems/camkes:latest
+
+RUN pip3 install junitparser
+
+COPY tutorials/steps.sh \
+     scripts/checkout-manifest.sh \
+     scripts/fetch-branch.sh \
+     scripts/repo-util \
+     /usr/bin/
+
+WORKDIR /usr/bin
+RUN chmod a+rx checkout-manifest.sh fetch-branch.sh repo-util steps.sh
+
+RUN mkdir /builds
+COPY tutorials/builds.yml \
+     tutorials/build.py \
+     seL4-platforms/platforms.yml \
+     seL4-platforms/platforms.py \
+     seL4-platforms/builds.py \
+     /builds/
+
+RUN mkdir -p /github/home
+
+ARG WORKSPACE
+RUN mkdir -p ${WORKSPACE}
+WORKDIR ${WORKSPACE}
+
+ENTRYPOINT steps.sh

--- a/tutorials/Makefile
+++ b/tutorials/Makefile
@@ -1,0 +1,24 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+default: build
+
+IMG=sel4/tutorials:latest
+
+build:
+	docker build -t $(IMG) -f Dockerfile ..
+
+push: build
+	docker push $(IMG)
+
+run: build
+	docker run -e GITHUB_REPOSITORY -e GITHUB_REF \
+	  -e GITHUB_WORKSPACE -e INPUT_ARCH -e INPUT_MARCH -e INPUT_MODE \
+		-e INPUT_COMPILER -e INPUT_DEBUG -e INPUT_MATRIX -e INPUT_NAME $(IMG)
+
+test: build
+	docker run -ti --entrypoint bash -e GITHUB_REPOSITORY -e GITHUB_REF \
+	  -e GITHUB_WORKSPACE -e INPUT_ARCH -e INPUT_MARCH -e INPUT_MODE \
+		-e INPUT_COMPILER -e INPUT_DEBUG -e INPUT_MATRIX -e INPUT_NAME \
+		-v $(shell pwd):/mnt:z $(IMG)

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -1,0 +1,87 @@
+<!--
+     Copyright 2021, Proofcraft Pty Ltd
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# seL4 Tutorial tests
+
+This action builds and runs the test suite for the [seL4 Tutorials]. The test
+runs can be restricted to specific `arch`, `app`, or full test `name` for use in
+a matrix build.
+
+The test runs a build from the default [sel4-tutorials-manifest], advancing the
+`sel4-tutorials` repository to the branch of the pull request the test is called
+on.
+
+[seL4 Tutorials]: https://github.com/seL4/sel4-tutorials
+[sel4-tutorials-manifest]: https://github.com/seL4/sel4-tutorials-manifest
+
+## Content
+
+The entry point is the script [steps.sh].
+
+[Build] configurations are in the respective yaml and python files in this
+repository. See these files for config documentation.
+
+The main test driver is [build.py] in this directory.
+
+[steps.sh]: ./steps.sh
+[build.py]: ./build.py
+[Build]: builds.yml
+
+## Arguments
+
+To add or modify build configurations, edit [builds.yml][Build] in this
+directory. To filter the build variants defined there for a specific run,
+use one or more of the following:
+
+- `arch`: comma separated list of architecture to filter on, e.g `arm, x86`.
+- `app`: comma separated list of `app` names, e.g. `hello-world`.
+- `name`: comma separated list of full test names, e.g. `pc99_hello-world`.
+- `matrix`: set to `true` to set the GitHub output variable `matrix` to a list
+            of tests fitting the selected criteria
+
+## Example
+
+Put this into a `.github/workflows/` yaml file, e.g. `test.yml`:
+
+```yaml
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    name: Tutorial Solution
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app:
+        - capabilities
+        - dynamic-1
+        - dynamic-2
+        - dynamic-3
+        - dynamic-4
+        - hello-camkes-0
+        - hello-camkes-1
+        - hello-camkes-2
+        - hello-camkes-timer
+        - hello-world
+        - interrupts
+        - ipc
+        - mapping
+        - notifications
+        - untyped
+        - threads
+        - fault-handlers
+        - mcs
+    steps:
+    - uses: seL4/ci-actions/tutorials@master
+      with:
+        app: ${{ matrix.app }}
+```

--- a/tutorials/action.yml
+++ b/tutorials/action.yml
@@ -1,0 +1,26 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: 'seL4 Tutorials'
+description: |
+  Runs the seL4 Tutorial test suite.
+author: Gerwin Klein <gerwin.klein@proofcraft.systems>
+
+inputs:
+  arch:
+    description: Comma separated list of archiectures to filter test configs on.
+    required: false
+  name:
+    description: Comma separated list of build names to filter build list on.
+    required: false
+  app:
+    description: Comma separated list of app names to filter build list on.
+    required: false
+  matrix:
+    description: Set to true to dump build matrix only
+    required: false
+
+runs:
+  using: 'docker'
+  image: 'docker://sel4/tutorials:latest'

--- a/tutorials/build.py
+++ b/tutorials/build.py
@@ -1,0 +1,63 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Parse builds.yml and run sel4test build + simulation on each of the build definitions.
+
+Expects seL4-platforms/ to be co-located or otherwise in the PYTHONPATH.
+"""
+
+from builds import Build, run_build_script, run_builds, load_builds, junit_results
+from pprint import pprint
+
+import json
+import os
+import sys
+
+# do not run listed apps for platform:
+disable_for = {
+    'PC99': ['hello-camkes-timer', 'interrupts'],
+    'ZYNQ7000': ['camkes-vm-linux', 'camkes-vm-crossvm', 'mapping', 'notifications', 'mcs']
+}
+
+
+def run_simulation(manifest_dir: str, build: Build):
+    """Run one tutorial test."""
+
+    script = [
+        ["chown", "root", "/github/home"],  # otherwise Haskell `stack` crashes
+        ["bash", "-c",
+         f"../projects/sel4-tutorials/test.py --app={build.app} "
+         f"--config={build.get_platform().name.lower()} | tee {junit_results}"]
+    ]
+
+    return run_build_script(manifest_dir, build.name, script, junit=True)
+
+
+def build_filter(build: Build) -> bool:
+    return not build.app in disable_for.get(build.get_platform().name, [])
+
+
+def to_json(builds: list) -> dict:
+    """Return a GitHub build matrix as GitHub set-output.
+
+    Basically just returns a list of build names that we can then
+    filter on."""
+
+    matrix = {"include": [{"name": b.name} for b in builds]}
+    return "::set-output name=matrix::" + json.dumps(matrix)
+
+
+# If called as main, run all builds from builds.yml
+if __name__ == '__main__':
+    builds = load_builds(os.path.dirname(__file__) + "/builds.yml", build_filter)
+
+    if len(sys.argv) > 1 and sys.argv[1] == '--dump':
+        pprint(builds)
+        sys.exit(0)
+    elif len(sys.argv) > 1 and sys.argv[1] == '--matrix':
+        print(to_json(builds))
+        sys.exit(0)
+
+    sys.exit(run_builds(builds, run_simulation))

--- a/tutorials/builds.yml
+++ b/tutorials/builds.yml
@@ -1,0 +1,37 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+---
+
+variants:
+    app:
+    - capabilities
+    - dynamic-1
+    - dynamic-2
+    - dynamic-3
+    - dynamic-4
+    - hello-camkes-0
+    - hello-camkes-1
+    - hello-camkes-2
+    - hello-camkes-timer
+    - hello-world
+    - interrupts
+    - ipc
+    - mapping
+    - notifications
+    - untyped
+    - threads
+    - fault-handlers
+    - mcs
+    # disabled until they can be simulated
+    # - camkes-vm-linux
+    # - camkes-vm-crossvm
+
+builds:
+  - pc99:
+      platform: PC99
+      mode: 64
+
+  - zynq7000:
+      platform: ZYNQ7000

--- a/tutorials/steps.sh
+++ b/tutorials/steps.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright 2021, Proofcfraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# Docker entrypoint for seL4 cparser test
+
+set -e
+
+# It's a bit overkill to pull a huge docker container for just dumping the build
+# matrix, but it's not really worth setting up a separate action for it, either.
+if [ -n "${INPUT_MATRIX}" ]
+then
+  python3 /builds/build.py --matrix
+  exit 0
+fi
+
+echo "::group::Setting up"
+export REPO_MANIFEST="default.xml"
+export MANIFEST_URL="https://github.com/seL4/sel4-tutorials-manifest.git"
+checkout-manifest.sh
+
+cd $(repo-util path ${GITHUB_REPOSITORY})
+fetch-branch.sh
+cd - >/dev/null
+
+repo-util hashes
+echo "::endgroup::"
+
+# start test
+python3 /builds/build.py


### PR DESCRIPTION
Adds a GitHub action for the seL4 tutorial tests. 

- can be filtered by app, test name, and arch
- can dump a full build matrix (turns out to be too large to make much sense on GitHub, but leaving the code here in case it is useful elsewhere later)
- includes some cleanup and refactoring of generic code to simplify the setup of this action
- add colour to logs for sel4test-type logs (like this one); this will take effect of other actions as well
