### PR TITLE
camkes-vm: add Arm builds

### DIFF
--- a/camkes-vm/Makefile
+++ b/camkes-vm/Makefile
@@ -16,12 +16,12 @@ run: build
 	docker run --rm -e GITHUB_REPOSITORY -e GITHUB_REF \
 	  -e GITHUB_WORKSPACE -e INPUT_ARCH -e INPUT_MARCH -e INPUT_MODE \
 		-e INPUT_COMPILER -e INPUT_DEBUG -e INPUT_MATRIX -e INPUT_NAME \
-		-e INPUT_REQ $(IMG)
+		-e INPUT_REQ -e INPUT_PLATFORM $(IMG)
 
 # pass in a dummy HOME directory to simulate GitHub changing HOME
 test: build
 	docker run --rm -ti --entrypoint bash -e GITHUB_REPOSITORY -e GITHUB_REF \
 	  -e GITHUB_WORKSPACE -e INPUT_ARCH -e INPUT_MARCH -e INPUT_MODE \
 		-e INPUT_COMPILER -e INPUT_DEBUG -e INPUT_MATRIX -e INPUT_NAME \
-		-e INPUT_REQ -e HOME=/tmp \
+		-e INPUT_REQ -e INPUT_PLATFORM -e HOME=/tmp \
 		-v $(shell pwd):/mnt:z $(IMG)

--- a/camkes-vm/README.md
+++ b/camkes-vm/README.md
@@ -31,6 +31,7 @@ directory. To filter the build variants defined there for a specific run,
 use one or more of the following:
 
 - `name`: comma separated list of full test names, e.g. `optiplex9020`.
+- `march`: comma separated list of march, e.g. `armv7a, armv8a`.
 
 ## Example
 

--- a/camkes-vm/action.yml
+++ b/camkes-vm/action.yml
@@ -11,6 +11,9 @@ inputs:
   name:
     description: 'Name of the build to run (for matrix builds)'
     required: false
+  march:
+    description: 'Comma-separated list of march to filter on (for matrix builds)'
+    required: false
 
 runs:
   using: 'docker'

--- a/camkes-vm/build.py
+++ b/camkes-vm/build.py
@@ -24,17 +24,34 @@ import sys
 def run_build(manifest_dir: str, build: Build):
     """Run one CAmkES VM test."""
 
-    build.files = build.get_platform().image_names(build.get_mode(), "capdl-loader")
-    build.settings['CAMKES_VM_APP'] = build.name
+    plat = build.get_platform()
+
+    build.files = plat.image_names(build.get_mode(), "capdl-loader")
+    build.settings['CAMKES_VM_APP'] = build.app or build.name
     del build.settings['BAMBOO']    # not used in this test, avoid warning
-    del build.settings['PLATFORM']  # not used in this test, avoid warning
+
+    if plat.arch == 'x86':
+        del build.settings['PLATFORM']  # not used for x86 in this test, avoid warning
+        # build.req set by default in builds.yml for x86
+    else:
+        build.req = plat.req or plat.name.lower()
 
     script = [
         ["../init-build.sh"] + build.settings_args(),
         ["ninja"],
         ["tar", "czf", f"../{build.name}-images.tar.gz", "images/"],
-        ["echo", f"hardware run for {build.req}, skipping"]
     ]
+
+    if plat.simulation_binary:
+        script.append(
+            ["bash", "-c",
+             f"expect -c 'spawn ./simulate; set timeout 3000; expect \"{build.success}\"'"]
+        )
+
+    if not plat.disabled:
+        script.append(["echo", f"Hardware run for {build.req}, skipping"])
+    else:
+        script.append(["echo", f"Platform for build {build.name} disabled, skipping"])
 
     return run_build_script(manifest_dir, build.name, script)
 

--- a/camkes-vm/builds.yml
+++ b/camkes-vm/builds.yml
@@ -12,6 +12,7 @@ default:
   req: haswell3
 
 builds:
+# PC99:
 - optiplex9020:
     mode: 64
 - minimal:
@@ -20,3 +21,62 @@ builds:
     mode: 64
     success: 'Finished running all scenarios'
     error: 'Exited with error'
+
+# Arm:
+- vm_minimal_tk1:
+    app: vm_minimal
+    platform: TK1
+- odroid_vm:
+    platform: ODROID_XU
+    succes: 'root@NICTAcopter:'
+- vm_minimal_tx1:
+    app: vm_minimal
+    platform: TX1
+- vm_minimal_tx2:
+    app: vm_minimal
+    platform: TX2
+- vm_minimal_sim:
+    app: vm_minimal
+    platform: ARMVIRT
+    sim: true
+- vm_minimal_xu4:
+    app: vm_minimal
+    platform: ODROID_XU4
+- vm_minimal_smp_tx1:
+    app: vm_minimal
+    platform: TX1
+    setttings:
+        NUM_NODES: 4
+- vm_minimal_smp_tx2:
+    app: vm_minimal
+    platform: TX2
+    setttings:
+        NUM_NODES: 4
+- vm_serial_server:
+    platform: ODROID_XU4
+- vm_virtio_net_arping_xu4:
+    app: vm_virtio_net
+    platform: ODROID_XU4
+    succes: 'arping test was successful'
+- vm_virtio_net_ping_xu4:
+    app: vm_virtio_net
+    platform: ODROID_XU4
+    succes: 'Ping test was successful'
+    setttings:
+        VIRTIO_NET_PING: '1'
+- vm_virtio_net_arping_tx2:
+    app: vm_virtio_net
+    platform: TX2
+    succes: 'arping test was successful'
+- vm_virtio_net_ping_tx2:
+    app: vm_virtio_net
+    platform: TX2
+    succes: 'Ping test was successful'
+    setttings:
+        VIRTIO_NET_PING: '1'
+- vm_multi:
+    platform: ODROID_XU4
+    success: 'buildroot login:.*buildroot login:.*buildroot login:'
+- vm_cross_connector:
+    platform: ODROID_XU4
+    succes: 'Finished crossvm test script'


### PR DESCRIPTION
These used to run in a separate test on Bamboo, which used the retired camkes-arm-vm-manifest. Now unified in here.
