### PR TITLE
improvements for aws-proofs

### DIFF
--- a/aws-proofs/kernel-sloc.sh
+++ b/aws-proofs/kernel-sloc.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Copyright CSIRO
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Estimate lines of code in preprocessed kernel.
+
+KERNEL=l4v/spec/cspec/c/build/${L4V_ARCH}/kernel_all.c_pp
+
+drop_multiline_comments() {
+    sed -e '/^ *\/\*\([^*]\|\*[^/]\)*$/,/*\/ *$/ d' "$@"
+}
+
+drop_oneline_comments() {
+    grep -v '^ */\*.*\*/ *$' "$@"
+}
+
+drop_cplusplus_comments() {
+    grep -v '^ *//' "$@"
+}
+
+drop_PP_directives() {
+    grep -v '^ *#' "$@"
+}
+
+drop_blank_lines() {
+    grep -v '^ *\(;\)\?$' "$@"
+}
+
+trim_C_source() {
+    drop_multiline_comments | \
+    drop_oneline_comments | \
+    drop_cplusplus_comments | \
+    drop_PP_directives | \
+    drop_blank_lines
+}
+
+if [ -e "$KERNEL" ]; then
+    SLOC=$(trim_C_source < "$KERNEL" | wc -l)
+else
+    SLOC=N/A
+fi
+
+echo "SLOC measure for $KERNEL: $SLOC"

--- a/aws-proofs/sorry-count.sh
+++ b/aws-proofs/sorry-count.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Copyright 2021 ProofCraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# Count number of sorries per major proof directory
+
+count() {
+    D="$1"
+    TMP=`mktemp -q` || exit 1
+    git grep -w sorry -- "${D}" > "${TMP}"
+    if [ "$?" = "0" ]
+    then
+        SORRIES=$(wc -l < "${TMP}")
+        echo "Sorries in ${D}: ${SORRIES}"
+    fi
+    rm "${TMP}"
+}
+
+TOP_DIRS="lib sys-init camkes"
+SND_DIRS="spec proof"
+
+for D in ${TOP_DIRS}; do count "$D"; done
+
+for L1 in ${SND_DIRS}; do
+    for D in $(find ${L1} -maxdepth 1 -mindepth 1 -type d); do count "$D"; done
+done

--- a/aws-proofs/vm-steps.sh
+++ b/aws-proofs/vm-steps.sh
@@ -76,15 +76,7 @@ export SKIP_DUPLICATED_PROOFS=${INPUT_SKIP_DUPS}
 FAIL=0
 
 cd l4v
-if [ "${INPUT_SESSION}" = "CRefine" ]
-then
-  # special treatment for CRefine session to speed up seL4 code change checks
-
-  cd proof
-  make CRefine || FAIL=1
-  cd ..
-
-elif [ -n ${INPUTSESSION} ]
+if [ -n ${INPUT_SESSION} ]
 then
   ./run_tests -v ${INPUT_SESSION} || FAIL=1
 else

--- a/aws-proofs/vm-steps.sh
+++ b/aws-proofs/vm-steps.sh
@@ -95,6 +95,8 @@ cd ..
 echo
 echo "Stats:"
 ~/ci-actions/aws-proofs/kernel-sloc.sh
+echo ""
+cd l4v; ~/ci-actions/aws-proofs/sorry-count.sh; cd ..
 
 echo "::endgroup::"
 

--- a/aws-proofs/vm-steps.sh
+++ b/aws-proofs/vm-steps.sh
@@ -92,6 +92,10 @@ else
 fi
 cd ..
 
+echo
+echo "Stats:"
+~/ci-actions/aws-proofs/kernel-sloc.sh
+
 echo "::endgroup::"
 
 echo "::group::Cache and logs"


### PR DESCRIPTION
- fix a small bug (would never fall-through to `-x AutoCorresSEL4`)
- add sorry count
- add kernel sloc

The sorry count could still be a bit nicer (show diff), and I might add that in the future, but this is better than none.