### PR TITLE
add action for repo-checkout + recording version

### DIFF
--- a/repo-checkout/README.md
+++ b/repo-checkout/README.md
@@ -1,0 +1,58 @@
+<!--
+     Copyright 2021, Proofcraft Pty Ltd
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Repo manifest checkout and version
+
+A separate action to check out a repo manifest, such as [sel4test-manifest], to
+advance the manifest to the state of a PR or branch (currently for a single repo
+only), and to record that state for later use by other actions.
+
+This mostly exists to make sure that separate jobs in a matrix build see exactly
+the same sources, especially when there are job dependencies and one or more jobs
+could start signficantly (hours) later than others. If manifests or branches are
+updated in between, the later job might otherwise see different sources.
+
+[sel4test-manifest]: https://github.com/seL4/sel4test-manifest
+
+## Content
+
+The steps of this action are defined in [steps.sh].
+
+[steps.sh]: ./steps.sh
+
+## Arguments
+
+- `manifest_repo` (required): the manifest repostory to check out (e.g. 'sel4test-manifest')
+- `manifest`: the manifest file to use (default `master.xml`)
+- `sha:`: override sha to advance PR repo to (e.g. sha for `seL4` repo in `seL4/sel4test-manifest`
+          if seL4 is the repo the action is called from)
+
+## Outputs
+
+- `xml`: the output of `repo manifest -r` in the PR/branch state.
+
+## Example
+
+```yml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    outputs:
+      xml: ${{ steps.repo.outputs.xml }}
+    steps:
+    - uses: seL4/ci-actions/repo-checkout@repo
+      id: repo
+      with:
+        manifest_repo: sel4test-manifest
+
+  test2:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${XML}"
+        env:
+          XML: ${{ needs.test.outputs.xml }}
+```

--- a/repo-checkout/action.yml
+++ b/repo-checkout/action.yml
@@ -1,0 +1,34 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: 'seL4Test/Hardware Runs'
+description: |
+  Does sel4test test runs from previously built images for all hardware test platforms.
+author: Gerwin Klein <gerwin.klein@proofcraft.systems>
+
+inputs:
+  manifest_repo:
+    description: Manifest repostory (e.g. 'sel4test-manifest')
+    required: true
+  manifest:
+    description: Manifest file
+    default: master.xml
+    required: false
+  sha:
+    description: |
+      override sha to advance PR repo to (e.g. sha for seL4 repo in
+      seL4/sel4test-manifest if seL4 is the repo the action is called from)
+    required: false
+  action_name:
+    description: 'internal -- do not use'
+    required: false
+    default: 'repo-checkout'
+
+outputs:
+  xml:
+    description: repo manifest as xml, target repo advanced to PR/branch
+
+runs:
+  using: 'node12'
+  main: '../js/index.js'

--- a/repo-checkout/steps.sh
+++ b/repo-checkout/steps.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Copyright 2021, Proofcfraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+set -e
+
+echo "::group::Setting up"
+
+mkdir -p ~/bin
+curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
+chmod a+x ~/bin/repo
+PATH=~/bin:$PATH
+
+echo "::endgroup::"
+
+echo "::group::Repo checkout"
+
+export REPO_MANIFEST="${INPUT_MANIFEST}"
+export MANIFEST_URL="https://github.com/seL4/${INPUT_MANIFEST_REPO}"
+checkout-manifest.sh
+
+cd $(repo-util path ${GITHUB_REPOSITORY})
+fetch-branch.sh
+cd - >/dev/null
+
+repo-util hashes
+
+echo "::endgroup::"
+
+XML="$(repo manifest -r --suppress-upstream-revision | nl-escape.sh)"
+echo "::set-output name=xml::${XML}"

--- a/scripts/checkout-manifest.sh
+++ b/scripts/checkout-manifest.sh
@@ -27,4 +27,13 @@ git config color.ui > /dev/null || \
 echo "Starting repo checkout on branch ${REPO_BRANCH} with manifest ${REPO_MANIFEST}:"
 
 $REPO init --depth ${REPO_DEPTH} -m ${REPO_MANIFEST} -b ${REPO_BRANCH} -u "${MANIFEST_URL}"
+
+# if explicit manifest is provided via input XML, switch to that instead
+if [ -n "${INPUT_XML}" ]
+then
+  TEST_XML="the-test.xml"
+  echo "${INPUT_XML}" > ".repo/manifests/${TEST_XML}"
+  $REPO init --depth ${REPO_DEPTH} -m "${TEST_XML}"
+fi
+
 $REPO sync

--- a/scripts/fetch-branch.sh
+++ b/scripts/fetch-branch.sh
@@ -4,21 +4,27 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-# Fetches the branch in ${GITHUB_REF} into a repo manifest checkout
+# Fetches the branch in ${GITHUB_REF} into a repo manifest checkout.
+# Does nothing if INPUT_XML is set, because that means we have already done this.
 
-# Assumes a repo manifest checkout, and current working dir in the repo
-# to fetch the branch for.
-
-URL="https://github.com/${GITHUB_REPOSITORY}.git"
-
-# if an explicit SHA is set as INPUT (e.g. for pull request target), prefer that over GITHUB_REF
-if [ -n "${INPUT_SHA}" ]
+if [ -z "${INPUT_XML}" ]
 then
-  REF=${INPUT_SHA}
-else
-  REF=${GITHUB_REF}
-fi
 
-echo "Fetching ${REF} from ${URL}"
-git fetch -q --depth 1 ${URL} ${REF}:${REF}
-git checkout -q ${REF}
+  # Assumes a repo manifest checkout, and current working dir in the repo
+  # to fetch the branch for.
+
+  URL="https://github.com/${GITHUB_REPOSITORY}.git"
+
+  # if an explicit SHA is set as INPUT (e.g. for pull request target), prefer that over GITHUB_REF
+  if [ -n "${INPUT_SHA}" ]
+  then
+    REF=${INPUT_SHA}
+  else
+    REF=${GITHUB_REF}
+  fi
+
+  echo "Fetching ${REF} from ${URL}"
+  git fetch -q --depth 1 ${URL} ${REF}:${REF}
+  git checkout -q ${REF}
+
+fi

--- a/scripts/nl-escape.sh
+++ b/scripts/nl-escape.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Escape %, \n, \r for GitHub value setting. It is un-escaped automatically by GH.
+
+# portable sed is no good for newline replacement, but there is always perl
+perl -pe 's/%/%25/g' | perl -pe 's/\n/%0A/g' | perl -pe 's/\r/%0D/g'


### PR DESCRIPTION
The idea is that further actions can take the version output of this as input to make sure that matrix jobs all test the same revisions.

The action fetches the `repo` manifest, checks out the PR branch, and records the output of `repo manifest -r` as the repo state.

Step 1 for #136