### PR TITLE
aws-proofs: enable testboard

### DIFF
--- a/aws-proofs/vm-steps.sh
+++ b/aws-proofs/vm-steps.sh
@@ -19,9 +19,15 @@ then
   export REPO_MANIFEST="${INPUT_MANIFEST}"
 fi
 
+TESTBOARD=seL4/gh-testboard
+if [ "${GITHUB_REPOSITORY}" = "${TESTBOARD}" ]
+then
+  export MANIFEST_URL="https://github.com/${TESTBOARD}.git"}
+fi
+
 checkout-manifest.sh
 
-if [ -n "${INPUT_ISA_BRANCH}" -a -z "${INPUT_XML}" ]
+if [ -n "${INPUT_ISA_BRANCH}" ] && [ -z "${INPUT_XML}" ]
 then
   cd isabelle
   echo "Fetching ${INPUT_ISA_BRANCH} from remote \"verification\""
@@ -30,16 +36,14 @@ then
   cd ..
 fi
 
-cd $(repo-util path ${GITHUB_REPOSITORY})
 echo "Testing ${GITHUB_REPOSITORY}"
 
-if [ -z ${GITHUB_BASE_REF} ]
+if [ "${GITHUB_REPOSITORY}" != "${TESTBOARD}" ]
 then
+  cd $(repo-util path ${GITHUB_REPOSITORY})
   fetch-branch.sh
-else
-  fetch-pr.sh
+  cd - >/dev/null
 fi
-cd - >/dev/null
 
 repo-util hashes
 


### PR DESCRIPTION
Together with adding a workflow in the [gh-testboard](https://github.com/seL4/gh-testboard) repo this enables running testboards as before, just triggered from GitHub.

Results should arrive via email for the committer, and be visible on the status of the testboard commit.

(Also removes `fetch-pr.sh` in favour of always using `fetch-branch.sh`, because we don't need history between base and head for the proof test)