### PR TITLE
simultaneous PR testing for proofs

### DIFF
--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -9,6 +9,15 @@
 # For now we keep an active ssh session during the test so that we get live
 # logs.
 
+if [ "${GITHUB_EVENT_NAME}" = "pull_request_target" ] ||
+   [ "${GITHUB_EVENT_NAME}" = "pull_request" ]
+then
+  echo "::group::PR info"
+  pip3 install -U PyGithub
+  INPUT_EXTRA_PRS="$(get-prs)"
+  echo "::endgroup::"
+fi
+
 echo "::group::AWS"
 # fail on any error
 set -e
@@ -69,6 +78,7 @@ ssh -o SendEnv=INPUT_CI_BRANCH \
     -o SendEnv=INPUT_CACHE_WRITE \
     -o SendEnv=INPUT_SKIP_DUPS \
     -o SendEnv=INPUT_XML \
+    -o SendEnv=INPUT_EXTRA_PRS \
     -o SendEnv=GITHUB_REPOSITORY \
     -o SendEnv=GITHUB_REF \
     -o SendEnv=GITHUB_BASE_REF \

--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -5,8 +5,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-# The GitHub action mostly starts up an AWS and hands over to there. For now we
-# keep an active ssh session during the test so that we get live logs.
+# The GitHub action mostly starts up an AWS instance and hands over to there.
+# For now we keep an active ssh session during the test so that we get live
+# logs.
 
 echo "::group::AWS"
 # fail on any error

--- a/aws-proofs/vm-steps.sh
+++ b/aws-proofs/vm-steps.sh
@@ -44,6 +44,8 @@ then
   cd $(repo-util path ${GITHUB_REPOSITORY})
   fetch-branch.sh
   cd - >/dev/null
+
+  fetch-extra-prs.sh
 fi
 
 repo-util hashes

--- a/scripts/fetch-extra-prs.sh
+++ b/scripts/fetch-extra-prs.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Fetch extra pull requests in $INPUT_EXTRA_PRS unless $INPUT_XML is set
+# Expect INPUT_EXTRA_PRS to be space separated list of org/repo#num
+
+if [ -z "${INPUT_XML}" ] && [ -n "${INPUT_EXTRA_PRS}" ]
+then
+
+  for PR in ${INPUT_EXTRA_PRS}
+  do
+    REPO=${PR%#*}
+    ID=${PR#*#}
+
+    URL="https://github.com/${REPO}.git"
+    REF="refs/pull/${ID}/head"
+
+    cd $(repo-util path ${REPO})
+    echo "Fetching ${REF} from ${URL}"
+    git fetch -q --depth 1 ${URL} ${REF}:${REF}
+    git checkout -q ${REF}
+    cd - > /dev/null
+  done
+
+fi

--- a/scripts/get-prs
+++ b/scripts/get-prs
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+#
+# Copyright 2021 Proofcraft Pty Ltd
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Parse a PR description body for comments of the form
+#   "Test with org/repo#id ((, | and) org/repo#id)*"
+#
+# Expects a GitHub event file to be available for the PR number.
+#
+# Outputs space separated list of "org/repo#id"
+# Outputs empty string if no such references.
+#
+# Fails if not a PR.
+
+import json
+import os
+import re
+import sys
+
+from github import Github
+
+test_start_re = "[Tt]est with:?"
+repo_ref_re = "([a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+#[0-9]+)"
+pr_re = re.compile(repo_ref_re)
+repo_sep_re = "([, ]+(and)?[ ]*)"
+test_re = re.compile(f"{test_start_re}[ ]*({repo_ref_re}{repo_sep_re}?)+")
+
+if __name__ == '__main__':
+    if os.environ['GITHUB_EVENT_NAME'] != 'pull_request' and \
+       os.environ['GITHUB_EVENT_NAME'] != 'pull_request_target':
+        print('Not a pull request')
+        sys.exit(1)
+
+    with open(os.environ['GITHUB_EVENT_PATH']) as f:
+      event = json.load(f)
+    number = event['number']
+
+    # get body dynamically so we don't miss updates on test re-run:
+    gh = Github()
+    repo = gh.get_repo(os.environ['GITHUB_REPOSITORY'])
+    issue = repo.get_issue(number=int(number))
+
+    prs = []
+    for line in issue.body.split('\n'):
+        if test_re.match(line):
+          prs.extend(pr_re.findall(line))
+
+    print(" ".join(prs))


### PR DESCRIPTION
This is the first step for doing this in all repos (#102). The PR parsing code is tested, but the rest is a bit hard to test for the proofs, so I think we'll have to merge and fix any potential breakage afterwards.

The format for requesting pulling in another PR for a test is one or more lines like the following anywhere in the PR description:

Test with seL4/some-repo#10 and some-org/some_other_repo#4
