### PR TITLE
action for seL4 release script

### DIFF
--- a/manifest-deploy/README.md
+++ b/manifest-deploy/README.md
@@ -1,0 +1,65 @@
+<!--
+     Copyright 2021, Proofcraft Pty Ltd
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Deploy manifest updates
+
+Deals with automatic updates to the `default.xml` file in manifest repositories
+such as [sel4test-manifest] after successful tests.
+
+[sel4test-manifest]: https://github.com/seL4/sel4test-manifest
+
+## Content
+
+The steps of this action are defined in [steps.sh].
+
+The main manifest update work happens in the `releaseit` script of the
+seL4_release repository that is currently still private (to be published).
+
+[steps.sh]: ./steps.sh
+
+## Arguments
+
+- `xml`: the manifest file to update to
+- `manifest_repo`: the manifest repository to deploy to
+
+## Environment
+
+- `GH_SSH`: ssh key with write access to the manifest repository
+
+## Example
+
+```yml
+jobs:
+  code:
+    runs-on: ubuntu-latest
+    outputs:
+      xml: ${{ steps.repo.outputs.xml }}
+    steps:
+    - id: repo
+      uses: seL4/ci-actions/repo-checkout@master
+      with:
+        manifest_repo: sel4test-manifest
+        manifest: master.xml
+
+  test:
+    needs: code
+    runs-on: ubuntu-latest
+    steps:
+    - uses: seL4/ci-actions/...@master
+      with:
+        xml: ${{ needs.code.outputs.xml }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [code, test]
+    steps:
+    - uses: seL4/ci-actions/manifest-deploy@master
+      with:
+        xml: ${{ needs.code.outputs.xml }}
+        manifest_repo: sel4test-manifest
+      env:
+        GH_SSH: ${{ secrets.CI_SSH }}
+```

--- a/manifest-deploy/action.yml
+++ b/manifest-deploy/action.yml
@@ -1,0 +1,25 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: 'Deploy sel4test and other manifests after test'
+description: |
+  Constructs default.xml manifests after successful test and deploys it to
+  the corresponding manifest repo.
+author: Gerwin Klein <gerwin.klein@proofcraft.systems>
+
+inputs:
+  xml:
+    description: manifest to deploy in xml
+    required: true
+  manifest_repo:
+    description: the manifest repository to deploy to
+    required: false
+  action_name:
+    description: 'internal -- do not use'
+    required: false
+    default: 'manifest-deploy'
+
+runs:
+  using: 'node12'
+  main: '../js/index.js'

--- a/manifest-deploy/steps.sh
+++ b/manifest-deploy/steps.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright 2021, Proofcfraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+set -e
+
+echo "::group::Setting up"
+echo "Installing 'repo'"
+mkdir -p ~/bin
+curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
+chmod a+x ~/bin/repo
+
+PATH=~/bin:"${GITHUB_WORKSPACE}/seL4_release":$PATH
+
+echo "Setting up ssh"
+eval $(ssh-agent)
+ssh-add -q - <<< "${GH_SSH}"
+
+echo "Fetching seL4_release repo"
+git clone --depth 1 ssh://git@github.com/seL4/seL4_release
+
+echo "Installing python dependencies"
+pip3 install --user -r ${GITHUB_WORKSPACE}/seL4_release/requirements.txt
+
+echo "Install doxygen"
+sudo apt-get install -qq doxygen
+echo "::endgroup::"
+
+echo "::group::Repo checkout"
+export MANIFEST_URL="ssh://git@github.com/seL4/${INPUT_MANIFEST_REPO}.git"
+export REPO_MANIFEST=master.xml
+export REPO_DEPTH=0
+checkout-manifest.sh
+repo-util hashes
+echo "::endgroup::"
+
+echo "::group::Deploy"
+releaseit nightly --release
+echo "::endgroup::"

--- a/repo-checkout/README.md
+++ b/repo-checkout/README.md
@@ -12,7 +12,7 @@ only), and to record that state for later use by other actions.
 
 This mostly exists to make sure that separate jobs in a matrix build see exactly
 the same sources, especially when there are job dependencies and one or more jobs
-could start signficantly (hours) later than others. If manifests or branches are
+could start significantly (hours) later than others. If manifests or branches are
 updated in between, the later job might otherwise see different sources.
 
 [sel4test-manifest]: https://github.com/seL4/sel4test-manifest
@@ -25,7 +25,7 @@ The steps of this action are defined in [steps.sh].
 
 ## Arguments
 
-- `manifest_repo` (required): the manifest repostory to check out (e.g. 'sel4test-manifest')
+- `manifest_repo` (required): the manifest repository to check out (e.g. 'sel4test-manifest')
 - `manifest`: the manifest file to use (default `master.xml`)
 - `sha:`: override sha to advance PR repo to (e.g. sha for `seL4` repo in `seL4/sel4test-manifest`
           if seL4 is the repo the action is called from)

--- a/repo-checkout/action.yml
+++ b/repo-checkout/action.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-name: 'seL4Test/Hardware Runs'
+name: 'Repo Checkout'
 description: |
   Does sel4test test runs from previously built images for all hardware test platforms.
 author: Gerwin Klein <gerwin.klein@proofcraft.systems>

--- a/sel4test-hw/README.md
+++ b/sel4test-hw/README.md
@@ -43,6 +43,7 @@ use one or more of the following:
 - `compiler`: one of `{gcc, clang}`
 - `debug`: comma separated list of debug levels from `{debug, release,
   verification}`  to filter on.
+- `xml`: [sel4test][sel4test-manifest] xml manifest to test
 
 ## Example
 

--- a/sel4test-hw/action.yml
+++ b/sel4test-hw/action.yml
@@ -28,6 +28,9 @@ inputs:
   sha:
     description: git sha to test
     required: false
+  xml:
+    description: sel4test xml manifest to test
+    required: false
   action_name:
     description: 'internal -- do not use'
     required: false

--- a/sel4test-sim/README.md
+++ b/sel4test-sim/README.md
@@ -43,6 +43,7 @@ use one or more of the following:
 - `compiler`: one of `{gcc, clang}`
 - `debug`: comma separated list of debug levels from `{debug, release,
   verification}`  to filter on.
+- `xml`: [sel4test][sel4test-manifest] xml manifest to test
 
 ## Example
 

--- a/sel4test-sim/action.yml
+++ b/sel4test-sim/action.yml
@@ -21,6 +21,9 @@ inputs:
   compiler:
     description: One of `{gcc, clang} to filter test configs on`
     required: false
+  xml:
+    description: sel4test xml manifest to test
+    required: false
   debug:
     description: |
       Comma separated list of debug levels from `{debug, release, verification}`


### PR DESCRIPTION
This is similar to [l4v-deploy](https://github.com/seL4/ci-actions/tree/master/l4v-deploy), but runs the seL4 release and bump script instead (which is increasingly misnomed `nightly`).
