### PR TITLE
add trigger action for repo manifest sets

### DIFF
--- a/trigger/README.md
+++ b/trigger/README.md
@@ -1,0 +1,96 @@
+<!--
+     Copyright 2021, Proofcraft Pty Ltd
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Trigger test on main repository
+
+Typically repos in the seL4 org are part of some Google repo manifest
+constellation. Each of these manifests has a main test suite that is running on
+one of the participating repositories (the "main" repo).
+
+Take for instance a simplified form of the manifest in `sel4test-manifest`:
+
+```xml
+<manifest>
+  ...
+  <project name="seL4" ... />
+  <project name="seL4_libs"  ... />
+  <project name="seL4_tools" ... >
+  ...
+</manifest>
+```
+
+and in addition a simplified version of the manifest `sel4bench-manifest`:
+
+```xml
+<manifest>
+  ...
+  <project name="seL4" ... />
+  <project name="seL4_libs"  ... />
+  <project name="sel4bench"  ... />
+  ...
+</manifest>
+```
+
+The main test suite for the `sel4test-manifest` repo is implemented in the
+GitHub workflows of the `seL4` repo. On pushes to the master branch of that
+repo, tests will run and a new `default.xml` manifest is deployed to
+`sel4test-manifest` when successful. The main test suite for
+`sel4bench-manifest` is in the `sel4bench` repository.
+
+Without further action, changes in the `seL4_libs` or `seL4_tools` repos will not
+trigger any test or manifest deployments, neither in `seL4` nor in `sel4bench`.
+Instead of duplicating the full test setup we have in the `seL4` and `seL4bench`
+repos, we instead use the `trigger` action implemented here to notify the `seL4`
+and `sel4bench` repos that a new test run should be kicked off.
+
+The `trigger` action implemented here knows which repositories each manifest
+contains (`seL4`, `seL4_libs`, `seL4_tools`, `sel4bench` etc), and where the
+main tests are for each manifest (e.g. in `seL4` and `sel4bench`). Test triggers
+are then sent to these test repos.
+
+The file [test-repos.yml] stores the information which manifests exist and where
+the main tests for each of these are. The information which messages to send on
+which changes is generated from that and the manifest files, and stored in
+[notify.yml].
+
+[seL4]: https://github.com/seL4/seL4
+[sel4test-manifest]: https://github.com/seL4/sel4test-manifest
+
+## Content
+
+The steps of this action are defined in [steps.sh], which in this case only
+calls [dispatch.py].
+
+For speed, [notify.yml] is generated statically and needs to be re-generated
+manually when projects are added/removed to/from manifests. Use [gen-notify.py]
+to do this.
+
+[steps.sh]: ./steps.sh
+[gen-notify.py]: ./gen-notify.py
+[dispatch.py]: ./dispatch.py
+[notify.yml]: ./notify.yml
+[test-repos.yml]: ./test-repos.yml
+
+## Arguments
+
+- `token`: authentication token with repo scope for repositories the
+           repository_dispatch event is sent to.
+
+## Example
+
+```yml
+on:
+  push:
+    branches: [master]
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: seL4/ci-actions/trigger@master
+      with:
+        token: $${{ secrets.REPO_TOKEN }}
+```

--- a/trigger/action.yml
+++ b/trigger/action.yml
@@ -1,0 +1,21 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: 'Trigger repository_dispatch'
+description: |
+  Trigger test run in the main repository of a repo manifest set.
+author: Gerwin Klein <gerwin.klein@proofcraft.systems>
+
+inputs:
+  token:
+    description: authentication token with repo scope for target repos.
+    required: true
+  action_name:
+    description: 'internal -- do not use'
+    required: false
+    default: 'trigger'
+
+runs:
+  using: 'node12'
+  main: '../js/index.js'

--- a/trigger/dispatch.py
+++ b/trigger/dispatch.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+#
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import yaml
+import requests
+import sys
+
+if __name__ == '__main__':
+    token = os.environ.get('INPUT_TOKEN')
+    if not token:
+        print("Need $INPUT_TOKEN for authentication.")
+        sys.exit(1)
+
+    src_repo = os.environ.get('GITHUB_REPOSITORY')
+    if not src_repo:
+        print("GITHUB_REPOSITORY not set.")
+        sys.exit(1)
+
+    if not src_repo.startswith('seL4/'):
+        print("This action is only for repositories in the seL4 GitHub org.")
+        sys.exit(1)
+
+    # remove 'seL4/' prefix and standardise case for lookup in notify.yml
+    src_repo = src_repo[5:].lower()
+
+    name = os.path.dirname(__file__) + "/notify.yml"
+    with open(name, 'r') as f:
+        notif = yaml.safe_load(f)
+
+    targets = notif.get(src_repo, [])
+
+    if targets == []:
+        print(f"No notification targets for {src_repo}.")
+
+    user = 'seL4-ci'
+    msg = {"event_type": "deps-update", "client_payload": {"sender": src_repo}}
+
+    print("Sending repository_dispatches:")
+
+    for repo in targets:
+        print(f"  Creating repository_dispatch for {repo}...", end='')
+        url = f"https://api.github.com/repos/seL4/{repo}/dispatches"
+        r = requests.post(url, auth=(user, token), json=msg, timeout=10)
+        if r.ok:
+            print(" done.")
+        else:
+            print(" failed.")
+
+    print("Done.")

--- a/trigger/gen-notify.py
+++ b/trigger/gen-notify.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+#
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Re-generates `notify.yml` from test-repos.yml and current manifest content on
+# GitHub
+
+import os
+from typing import List
+import yaml
+import tempfile
+from subprocess import run
+from xml.etree.ElementTree import parse as xml_parse
+from pprint import pprint
+from shutil import rmtree
+
+
+def get_test_repos() -> dict:
+    """ Load test-repo.yml mapping from manifest to main test repo. """
+    name = os.path.dirname(__file__) + "/test-repos.yml"
+    with open(name, 'r') as file:
+        return yaml.safe_load(file)
+
+
+def removesuffix(string: str, suffix: str) -> str:
+    """Like .removesuffix in python 3.9"""
+    if string.endswith(suffix):
+        return string[0:-len(suffix)]
+    else:
+        return string
+
+
+def get_manifest(repo: str) -> List[str]:
+    """ Return the list of project repos in default.xml of a manifest repo. """
+
+    url = "https://github.com/seL4/" + repo + ".git"
+
+    orig_dir = os.getcwd()
+    temp_dir = tempfile.mkdtemp()
+
+    try:
+        os.chdir(temp_dir)
+        run(['git', 'clone', '--depth', '1', url])
+        os.chdir(repo)
+
+        xml = xml_parse("default.xml")
+        repos = [prj.attrib['name'] for prj in xml.getroot().findall('project')]
+        return [removesuffix(r.lower(), '.git') for r in repos]
+
+    finally:
+        os.chdir(orig_dir)
+        rmtree(temp_dir)
+
+
+def add_to_map(map: dict, repos: List[str], notif: str) -> dict:
+    """ Add notification to each of the provided repos in the provided map. """
+
+    for r in repos:
+        if r != notif:
+            map[r] = map.get(r, []) + [notif]
+
+
+# file header for generated notif.yml
+header = """\
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+---
+
+# --- GENERATED -- DO NOT EDIT
+# run ./gen-notify.py to regenerate this file
+
+"""
+
+if __name__ == '__main__':
+    map = {}
+    for (manifest, notif) in get_test_repos().items():
+        repos = get_manifest(manifest)
+        add_to_map(map, repos, notif)
+
+    with open(os.path.dirname(__file__) + "/notify.yml", 'w') as f:
+        f.write(header)
+        yaml.dump(map, f)

--- a/trigger/notify.yml
+++ b/trigger/notify.yml
@@ -1,0 +1,130 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+---
+
+# --- GENERATED -- DO NOT EDIT
+# run ./gen-notify.py to regenerate this file
+
+cakeml_libs:
+- camkes-tool
+camkes:
+- camkes-tool
+camkes-arm-vm:
+- sel4webserver
+camkes-tool:
+- camkes-vm-examples
+- sel4-tutorials
+- sel4webserver
+camkes-vm:
+- camkes-vm-examples
+- sel4-tutorials
+- sel4webserver
+camkes-vm-images:
+- camkes-vm-examples
+- sel4webserver
+camkes-vm-linux:
+- camkes-vm-examples
+- sel4-tutorials
+- sel4webserver
+capdl:
+- camkes-tool
+- camkes-vm-examples
+- sel4-tutorials
+- sel4webserver
+cogent:
+- camkes-tool
+global-components:
+- camkes-tool
+- camkes-vm-examples
+- sel4-tutorials
+- sel4webserver
+graph-refine:
+- l4v
+hol:
+- l4v
+isabelle:
+- l4v
+libzmq:
+- camkes-vm-examples
+lwip:
+- camkes-tool
+- camkes-vm-examples
+musllibc:
+- seL4
+- sel4bench
+- camkes-tool
+- camkes-vm-examples
+- sel4-tutorials
+- sel4webserver
+nanopb:
+- seL4
+- sel4bench
+opensbi:
+- seL4
+- sel4bench
+- camkes-tool
+picotcp:
+- camkes-tool
+- camkes-vm-examples
+polly:
+- camkes-vm-examples
+- sel4-tutorials
+polyml:
+- l4v
+projects_libs:
+- sel4bench
+- camkes-tool
+- camkes-vm-examples
+- sel4-tutorials
+- sel4webserver
+pruner:
+- camkes-tool
+rumprun:
+- camkes-tool
+sel4:
+- l4v
+- seL4
+- sel4bench
+- camkes-tool
+- camkes-vm-examples
+- sel4-tutorials
+- sel4webserver
+sel4_libs:
+- seL4
+- sel4bench
+- camkes-tool
+- camkes-vm-examples
+- sel4-tutorials
+- sel4webserver
+sel4_projects_libs:
+- seL4
+- sel4bench
+- camkes-tool
+- camkes-vm-examples
+- sel4-tutorials
+- sel4webserver
+sel4_tools:
+- seL4
+- sel4bench
+- camkes-tool
+- camkes-vm-examples
+- sel4-tutorials
+- sel4webserver
+sel4runtime:
+- seL4
+- sel4bench
+- camkes-tool
+- camkes-vm-examples
+- sel4-tutorials
+- sel4webserver
+sel4test:
+- seL4
+util_libs:
+- seL4
+- sel4bench
+- camkes-tool
+- camkes-vm-examples
+- sel4-tutorials
+- sel4webserver

--- a/trigger/steps.sh
+++ b/trigger/steps.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Copyright 2021, Proofcfraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+python3 "${SCRIPTS}/../trigger/dispatch.py"

--- a/trigger/test-repos.yml
+++ b/trigger/test-repos.yml
@@ -1,0 +1,16 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+---
+
+# Maps manifest name to the repo that contains the main test setup for this
+# manifest. Assumes all repos are in the GitHub seL4 org.
+
+verification-manifest: l4v
+sel4test-manifest: seL4
+sel4bench-manifest: sel4bench
+camkes-manifest: camkes-tool
+camkes-vm-examples-manifest: camkes-vm-examples
+sel4-tutorials-manifest: sel4-tutorials
+sel4webserver-manifest: sel4webserver


### PR DESCRIPTION
Trigger test runs in the main repo of a manifest set.

Dependencies are encoded in notify.yml which is generated from manifest info (see REAMDE)