### PR TITLE
platforms: add tqma8xqp1gb platform

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -92,6 +92,14 @@ platforms:
     req: [imx8mm]
     march: armv8a
 
+  TQMA8XQP1GB:
+    arch: arm
+    modes: [64]
+    smp: [64]
+    aarch_hyp: [64]
+    platform: tqma8xqp1gb
+    march: armv8a
+
   KZM:
     arch: arm
     modes: [32]


### PR DESCRIPTION
This implements seL4/seL4#522 and should be merged after seL4/seL4#520.

(Hardware available at Breakaway)
