### PR TITLE
standalone-compile: drop python2 support

### DIFF
--- a/standalone-kernel/README.md
+++ b/standalone-kernel/README.md
@@ -30,12 +30,6 @@ The `COMPILER` input is the the choice of which compiler suite is to be used.
 Valid values are `gcc`, `llvm`.
 Note that not all `ARCH`s support all compilers.
 
-### PYTHON
-
-The `PYTHON` input is the the choice of which version of Python should be used during
-compilation.
-Valid values are `py2`, `py3`.
-
 They are best used in a matrix to run the test for all architectures
 concurrently.
 
@@ -52,7 +46,6 @@ standalone_kernel:
       matrix:
         arch: [ARM, ARM_HYP, RISCV64, X64]
         compiler: [gcc, llvm]
-        python: [py2, py3]
         exclude:
           # llvm RISCV64 compilation is not currently supported
           - arch: RISCV64

--- a/standalone-kernel/action.yml
+++ b/standalone-kernel/action.yml
@@ -17,15 +17,6 @@ inputs:
     description: 'Which compiler suite to use. One of gcc, llvm'
     required: true
 
-  PYTHON:
-    description: 'Which version of Python to use. One of py2, py3'
-    required: true
-
-  action_name:
-    description: 'internal -- do not use'
-    required: false
-    default: 'standalone-kernel'
-
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/standalone-kernel/compile_kernel.sh
+++ b/standalone-kernel/compile_kernel.sh
@@ -7,7 +7,6 @@
 
 echo "Arch: $INPUT_ARCH"
 echo "Comp: $INPUT_COMPILER"
-echo "Pyth: $INPUT_PYTHON"
 
 set -e
 
@@ -40,10 +39,6 @@ case $INPUT_ARCH in
         echo "Unknown ARCH"
         exit 1
 esac
-
-if [ "$INPUT_PYTHON" = "py3" ]; then
-    extra_config="${extra_config} -DPYTHON=python3"
-fi
 
 echo "::group::Run CMake"
 set -x


### PR DESCRIPTION
The build system has been on python3 default for some time already. This removes it from the standalone compile matrix in preparation of dropping python2 support completely.
