### PR TITLE
add diff_only option for style check

### DIFF
--- a/.stylefilter
+++ b/.stylefilter
@@ -1,0 +1,11 @@
+# Copyright 2021 Proofcraft Pty Ltd
+# SPDX-License-Identifier: BSD-2-Clause
+
+# scripts that use bash "<<<", which we do want:
+aws-proofs/steps.sh
+scripts/setup-hw-ssh.sh
+l4v-deploy/steps.sh
+manifest-deploy/steps.sh
+
+# uses bash nullglob, which we also do want:
+aws-proofs/vm-steps.sh

--- a/style/README.md
+++ b/style/README.md
@@ -16,7 +16,12 @@ just calls this script.
 
 ## Arguments
 
-None
+- `diff_only`: by default this action checks changed files on pull requests, and
+               all files on `push`. Set `diff_only` to true to only check the
+               diff on `push` as well. The diff is between the head of the branch
+               before the push and the current head of the branch. This breaks for
+               force-push, where the previous head of the branch might not exist
+               any more.
 
 ## Example
 

--- a/style/action.yml
+++ b/style/action.yml
@@ -7,6 +7,10 @@ description: 'Runs coding style checks of the seL4 Foundation'
 author: Gerwin Klein <kleing@unsw.edu.au>
 
 inputs:
+  diff_only:
+    description: even on "push", check only the diff to the head of the branch
+                 before the push, not all files. Does not work for force-push.
+    required: false
   action_name:
     description: 'internal -- do not use'
     required: false


### PR DESCRIPTION
Currently, we are checking the diff on PRs and all files on push, but we have some repositories that are not style-clean, and that we are only updating as we are touching files. In those situations, we will want the `push` style check on the diff, not on everything.