### PR TITLE
remove tests for KZM and armv6

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -99,16 +99,6 @@ platforms:
     platform: tqma8xqp1gb
     march: armv8a
 
-  KZM:
-    arch: arm
-    modes: [32]
-    platform: kzm
-    image_platform: imx31
-    req: [kzm]
-    simulation_binary: kzm11
-    march: armv6a
-    disabled: true
-
   OMAP3:
     arch: arm
     modes: [32]

--- a/sel4test-hw-run/README.md
+++ b/sel4test-hw-run/README.md
@@ -44,7 +44,7 @@ directory. To filter the build variants defined there for a specific run,
 use one or more of the following:
 
 - `arch`: comma separated list of architecture to filter on, e.g `arm, riscv`.
-- `march`: comma separated list of `march` flags, e.g. `armv6a, nehalem`
+- `march`: comma separated list of `march` flags, e.g. `armv7a, nehalem`
 - `mode`: one of `{32, 64}`
 - `compiler`: one of `{gcc, clang}`
 - `debug`: comma separated list of debug levels from `{debug, release,

--- a/sel4test-hw/README.md
+++ b/sel4test-hw/README.md
@@ -38,7 +38,7 @@ directory. To filter the build variants defined there for a specific run,
 use one or more of the following:
 
 - `arch`: comma separated list of architecture to filter on, e.g `arm, riscv`.
-- `march`: comma separated list of `march` flags, e.g. `armv6a, nehalem`
+- `march`: comma separated list of `march` flags, e.g. `armv7a, nehalem`
 - `mode`: one of `{32, 64}`
 - `compiler`: one of `{gcc, clang}`
 - `debug`: comma separated list of debug levels from `{debug, release,
@@ -61,7 +61,7 @@ jobs:
     steps:
     strategy:
           matrix:
-            march: ["armv6a, armv8a", armv7a, nehalem, rv32imac, rv64imac]
+            march: ["armv7a, armv8a", nehalem, rv32imac, rv64imac]
             compiler: [gcc, clang]
     steps:
     - uses: seL4/ci-actions/sel4test-hw@master

--- a/sel4test-sim/README.md
+++ b/sel4test-sim/README.md
@@ -38,7 +38,7 @@ directory. To filter the build variants defined there for a specific run,
 use one or more of the following:
 
 - `arch`: comma separated list of architecture to filter on, e.g `arm, riscv`.
-- `march`: comma separated list of `march` flags, e.g. `armv6a, nehalem`
+- `march`: comma separated list of `march` flags, e.g. `armv7a, nehalem`
 - `mode`: one of `{32, 64}`
 - `compiler`: one of `{gcc, clang}`
 - `debug`: comma separated list of debug levels from `{debug, release,
@@ -61,7 +61,7 @@ jobs:
     steps:
     strategy:
           matrix:
-            march: ["armv6a, armv8a", armv7a, nehalem, rv32imac, rv64imac]
+            march: ["armv7a, armv8a", nehalem, rv32imac, rv64imac]
             compiler: [gcc, clang]
     steps:
     - uses: seL4/ci-actions/sel4test-sim@master


### PR DESCRIPTION
Support for armv6 is removed from the kernel.

See also seL4/seL4#578