### PR TITLE
camkes-test: enable fixed manifest use

### DIFF
--- a/camkes-test/action.yml
+++ b/camkes-test/action.yml
@@ -17,6 +17,9 @@ inputs:
   mode:
     description: Comma separated list of modes to build for. One of `{32, 64}.`
     required: false
+  xml:
+    description: xml manifest to test
+    required: false
   matrix:
     description: If set, output build matrix and exit
     required: false


### PR DESCRIPTION
Deployment actions can take the entire manifest as input.
