### PR TITLE
bashisms: update link to 2.21.4

### DIFF
--- a/bashisms/README.md
+++ b/bashisms/README.md
@@ -39,6 +39,6 @@ jobs:
 ### Maintenance
 
 The `checkbashism` script in `../scripts` is directly extracted from
-<https://deb.debian.org/debian/pool/main/d/devscripts/devscripts_2.21.3.tar.xz>.
+<https://deb.debian.org/debian/pool/main/d/devscripts/devscripts_2.21.4.tar.xz>.
 Installing it via `apt-get` takes forever, because the rest of the devscripts
 has lots of dependencies.


### PR DESCRIPTION
Not changes in the checkbashisms script in this release.
