### PR TITLE
repeat and skip test runs

### DIFF
--- a/camkes-test/build.py
+++ b/camkes-test/build.py
@@ -74,7 +74,7 @@ def run_build(manifest_dir: str, build: Union[Build, SimBuild]):
     else:
         print(f"Warning: unknown build type for {build.name}")
 
-    return run_build_script(manifest_dir, build.name, script)
+    return run_build_script(manifest_dir, build, script)
 
 
 def hw_run(manifest_dir: str, build: Build):
@@ -87,7 +87,7 @@ def hw_run(manifest_dir: str, build: Build):
     build.success = apps[build.app]['success']
     script, final = build.hw_run('log.txt')
 
-    return run_build_script(manifest_dir, build.name, script, final_script=final)
+    return run_build_script(manifest_dir, build, script, final_script=final)
 
 
 def build_filter(build: Build):

--- a/camkes-test/build.py
+++ b/camkes-test/build.py
@@ -8,7 +8,7 @@ Parse builds.yml and run CAmkES test on each of the build definitions.
 Expects seL4-platforms/ to be co-located or otherwise in the PYTHONPATH.
 """
 
-from builds import Build, run_build_script, run_builds, load_builds, release_mq_locks
+from builds import Build, run_build_script, run_builds, load_builds, release_mq_locks, SKIP
 from pprint import pprint
 from typing import List, Union
 
@@ -82,7 +82,7 @@ def hw_run(manifest_dir: str, build: Build):
 
     if build.is_disabled():
         print(f"Build {build.name} disabled, skipping.")
-        return True
+        return SKIP
 
     build.success = apps[build.app]['success']
     script, final = build.hw_run('log.txt')

--- a/camkes-vm/build.py
+++ b/camkes-vm/build.py
@@ -45,7 +45,7 @@ def run_build(manifest_dir: str, build: Build):
              f"expect -c 'spawn ./simulate; set timeout 3000; expect \"{build.success}\"'"]
         )
 
-    return run_build_script(manifest_dir, build.name, script)
+    return run_build_script(manifest_dir, build, script)
 
 
 def hw_run(manifest_dir: str, build: Build):
@@ -60,7 +60,7 @@ def hw_run(manifest_dir: str, build: Build):
 
     script, final = build.hw_run('log.txt')
 
-    return run_build_script(manifest_dir, build.name, script, final_script=final)
+    return run_build_script(manifest_dir, build, script, final_script=final)
 
 
 # If called as main, run all builds from builds.yml

--- a/camkes-vm/build.py
+++ b/camkes-vm/build.py
@@ -8,7 +8,7 @@ Parse builds.yml and run CAmkES VM test on each of the build definitions.
 Expects seL4-platforms/ to be co-located or otherwise in the PYTHONPATH.
 """
 
-from builds import Build, run_build_script, run_builds, load_builds, release_mq_locks
+from builds import Build, run_build_script, run_builds, load_builds, release_mq_locks, SKIP
 from pprint import pprint
 
 import os
@@ -53,7 +53,7 @@ def hw_run(manifest_dir: str, build: Build):
 
     if build.is_disabled():
         print(f"Build {build.name} disabled, skipping.")
-        return True
+        return SKIP
 
     plat = build.get_platform()
     build.files = plat.image_names(build.get_mode(), "capdl-loader")

--- a/cparser-run/build.py
+++ b/cparser-run/build.py
@@ -25,7 +25,7 @@ def run_cparser(manifest_dir: str, build):
          '--underscore_idents', 'kernel/kernel_all_pp.c'],
     ]
 
-    return run_build_script(manifest_dir, build.name, script)
+    return run_build_script(manifest_dir, build, script)
 
 
 # If called as main, run all builds from builds.yml

--- a/rump-hello/build.py
+++ b/rump-hello/build.py
@@ -36,7 +36,7 @@ def run_build(manifest_dir: str, build: Build):
         script.append(["tar", "czf", f"../{build.name}-images.tar.gz", "images/"])
         script.append(["echo", f"hardware run for {build.req}, skipping"])
 
-    return run_build_script(manifest_dir, build.name, script)
+    return run_build_script(manifest_dir, build, script)
 
 
 # If called as main, run all builds from builds.yml

--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -245,7 +245,7 @@ class Run:
         build = self.build
 
         if build.is_disabled():
-            return [['echo', f"Platform {build.get_platform().name} disabled. Skipping."]], []
+            return [lambda r: SKIP], []
 
         machine = get_machine(self.get_req())
         if not machine:

--- a/sel4bench/build.py
+++ b/sel4bench/build.py
@@ -10,6 +10,7 @@ Expects seL4-platforms/ to be co-located or otherwise in the PYTHONPATH.
 
 from builds import Build, Run, run_build_script, run_builds, load_builds, load_yaml
 from builds import release_mq_locks, filtered, get_env_filters, printc, ANSI_RED
+from builds import SKIP, SUCCESS, REPEAT
 
 from pprint import pprint
 from typing import List

--- a/sel4test-hw/build.py
+++ b/sel4test-hw/build.py
@@ -9,6 +9,7 @@ Expects seL4-platforms/ to be co-located or otherwise in the PYTHONPATH.
 """
 
 from builds import Build, run_build_script, run_builds, load_builds, junit_results, release_mq_locks
+from builds import SKIP
 from pprint import pprint
 
 import os
@@ -32,7 +33,7 @@ def hw_run(manifest_dir: str, build: Build):
 
     if build.is_disabled():
         print(f"Build {build.name} disabled, skipping.")
-        return True
+        return SKIP
 
     script, final = build.hw_run(junit_results)
 

--- a/sel4test-hw/build.py
+++ b/sel4test-hw/build.py
@@ -24,7 +24,7 @@ def hw_build(manifest_dir: str, build: Build):
         ["tar", "czf", f"../{build.name}-images.tar.gz", "images/"]
     ]
 
-    return run_build_script(manifest_dir, build.name, script)
+    return run_build_script(manifest_dir, build, script)
 
 
 def hw_run(manifest_dir: str, build: Build):
@@ -36,7 +36,7 @@ def hw_run(manifest_dir: str, build: Build):
 
     script, final = build.hw_run(junit_results)
 
-    return run_build_script(manifest_dir, build.name, script, final_script=final, junit=True)
+    return run_build_script(manifest_dir, build, script, final_script=final, junit=True)
 
 
 def build_filter(build: Build) -> bool:

--- a/sel4test-sim/build.py
+++ b/sel4test-sim/build.py
@@ -27,7 +27,7 @@ def run_simulation(manifest_dir: str, build: Build):
          f"expect -c 'spawn ./simulate; set timeout 3000; expect {expect}' | tee {junit_results}"]
     ]
 
-    return run_build_script(manifest_dir, build.name, script, junit=True)
+    return run_build_script(manifest_dir, build, script, junit=True)
 
 
 # If called as main, run all builds from builds.yml

--- a/tutorials/build.py
+++ b/tutorials/build.py
@@ -26,7 +26,7 @@ def run_simulation(manifest_dir: str, build: Build):
          f"--config={build.get_platform().name.lower()} | tee {junit_results}"]
     ]
 
-    return run_build_script(manifest_dir, build.name, script, junit=True)
+    return run_build_script(manifest_dir, build, script, junit=True)
 
 
 def build_filter(build: Build) -> bool:


### PR DESCRIPTION
Refactor the test-run driver:
    
- a test command can now report that the test should be skipped and be
  marked as skipped. This should make skipped tests more easily visible.
    
- a test command can now report that the test run should be repeated.
  This is intended for hardware runs where the test command can may be
  able to recognize that a board did not boot properly or that output
  on the serial console was garbled.

- allow python functions in addition to shell commands in the test scripts

- mark skipped tests as SKIP
- repeat sel4bench runs on garbled JSON output
- repeat hardware runs on boot failure