### PR TITLE
docker: use new Debian 11 docker base images

### DIFF
--- a/camkes-test/Dockerfile
+++ b/camkes-test/Dockerfile
@@ -8,7 +8,7 @@ ARG WORKSPACE=/workspace
 ARG SCRIPTS=/ci-scripts
 ARG ACTION=camkes-test
 
-FROM trustworthysystems/camkes-cakeml-cogent-riscv-rust:latest
+FROM trustworthysystems/camkes-cakeml-cogent-rust:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/camkes-unit/Dockerfile
+++ b/camkes-unit/Dockerfile
@@ -4,7 +4,7 @@
 
 # The context for this Dockerfile is the repo root
 
-FROM trustworthysystems/camkes
+FROM trustworthysystems/camkes:lastest
 
 COPY scripts/*.sh camkes-unit/steps.sh /usr/bin/
 

--- a/cparser-run/Dockerfile
+++ b/cparser-run/Dockerfile
@@ -8,7 +8,7 @@ ARG WORKSPACE=/workspace
 ARG SCRIPTS=/ci-scripts
 ARG ACTION=cparser-run
 
-FROM trustworthysystems/sel4-riscv
+FROM trustworthysystems/sel4:latest
 
 COPY --from=sel4/cparser-builder /c-parser /c-parser
 

--- a/docker/cparser-builder.dockerfile
+++ b/docker/cparser-builder.dockerfile
@@ -12,14 +12,7 @@
 ARG WORKSPACE=/workspace
 ARG CP_DEST=/c-parser/standalone-parser
 
-FROM trustworthysystems/sel4 AS builder
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-       mlton \
-    && apt-get clean autoclean \
-    && apt-get autoremove --yes \
-    && rm -rf /var/lib/{apt,dpkg,cache,log}/
+FROM trustworthysystems/l4v:latest AS builder
 
 COPY scripts/checkout-manifest.sh /usr/bin/
 RUN chmod a+rx /usr/bin/checkout-manifest.sh

--- a/preprocess/Dockerfile
+++ b/preprocess/Dockerfile
@@ -8,7 +8,7 @@ ARG WORKSPACE=/workspace
 ARG SCRIPTS=/ci-scripts
 ARG ACTION=preprocess
 
-FROM trustworthysystems/sel4-riscv
+FROM trustworthysystems/sel4:latest
 
 COPY --from=sel4/cparser-builder /c-parser /c-parser
 

--- a/run-proofs/Dockerfile
+++ b/run-proofs/Dockerfile
@@ -4,7 +4,7 @@
 
 # The context for this Dockerfile is the repo root
 
-FROM trustworthysystems/l4v-riscv
+FROM trustworthysystems/l4v:latest
 
 COPY scripts/*.sh scripts/repo-util run-proofs/steps.sh /usr/bin/
 COPY run-proofs/settings /isabelle/etc/

--- a/seL4-manual/Dockerfile
+++ b/seL4-manual/Dockerfile
@@ -6,7 +6,7 @@
 
 ARG WORKSPACE=/workspace
 
-FROM trustworthysystems/sel4
+FROM trustworthysystems/sel4:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/sel4bench/Dockerfile
+++ b/sel4bench/Dockerfile
@@ -8,7 +8,7 @@ ARG WORKSPACE=/workspace
 ARG SCRIPTS=/ci-scripts
 ARG ACTION=sel4bench
 
-FROM trustworthysystems/sel4-riscv
+FROM trustworthysystems/sel4:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/sel4bench/build.py
+++ b/sel4bench/build.py
@@ -283,7 +283,7 @@ def gen_web(runs: List[Run], yml, file_name: str):
         f.write(f'<h2>Compilation Details</h2>\n')
 
         f.write(f'<p>')
-        f.write(f'All benchmarks were built using the trustworthy-systems/sel4-riscv\n')
+        f.write(f'All benchmarks were built using the trustworthy-systems/sel4\n')
         f.write(f'docker image from the <a href="https://github.com/seL4/seL4-CAmkES-L4v-dockerfiles">seL4\n')
         f.write(f'docker file repository</a>')
         f.write(f'</p>')

--- a/sel4test-hw/Dockerfile
+++ b/sel4test-hw/Dockerfile
@@ -8,7 +8,7 @@ ARG WORKSPACE=/workspace
 ARG SCRIPTS=/ci-scripts
 ARG ACTION=sel4test-hw
 
-FROM trustworthysystems/sel4-riscv
+FROM trustworthysystems/sel4:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/sel4test-sim/Dockerfile
+++ b/sel4test-sim/Dockerfile
@@ -8,7 +8,7 @@ ARG WORKSPACE=/workspace
 ARG SCRIPTS=/ci-scripts
 ARG ACTION=sel4test-sim
 
-FROM trustworthysystems/sel4-riscv
+FROM trustworthysystems/sel4:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/standalone-kernel/Dockerfile
+++ b/standalone-kernel/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-FROM trustworthysystems/sel4-riscv:latest
+FROM trustworthysystems/sel4:latest
 
 COPY compile_kernel.sh /compile_kernel.sh
 


### PR DESCRIPTION
These include the riscv toolchain in the base seL4 image already.
