### PR TITLE
platforms: add quartz64

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -67,6 +67,13 @@ platforms:
     march: armv8a
     disabled: true
 
+  QUARTZ64:
+    arch: arm
+    modes: [64]
+    platform: quartz64
+    march: armv8a
+    disabled: true
+
   ARMVIRT:
     arch: arm
     modes: [64]


### PR DESCRIPTION
The PR https://github.com/seL4/seL4/pull/727 add the platform "quartz64". Goal of this PR is adding it to the  hardware builds, so Github CI kann at least build it and highlight if something is broken.

- Is this the proepr way to add it?
- IN general, how can I test CI actions? Seems just using "Test with: ..., seL4/ci-actions#177" does not work.
