### PR TITLE
Update checkbashisms from 2.21.4 to 2.21.7

### DIFF
--- a/bashisms/README.md
+++ b/bashisms/README.md
@@ -39,6 +39,6 @@ jobs:
 ### Maintenance
 
 The `checkbashism` script in `../scripts` is directly extracted from
-<https://deb.debian.org/debian/pool/main/d/devscripts/devscripts_2.21.4.tar.xz>.
+<https://deb.debian.org/debian/pool/main/d/devscripts/devscripts_2.21.7.tar.xz>.
 Installing it via `apt-get` takes forever, because the rest of the devscripts
 has lots of dependencies.

--- a/scripts/checkbashisms
+++ b/scripts/checkbashisms
@@ -32,7 +32,7 @@ sub init_hashes;
 (my $progname = $0) =~ s|.*/||;
 
 my $usage = <<"EOF";
-Usage: $progname [-n] [-f] [-x] [-e] script ...
+Usage: $progname [-n] [-f] [-x] [-e] [-l] script ...
    or: $progname --help
    or: $progname --version
 This script performs basic checks for the presence of bashisms
@@ -49,7 +49,7 @@ You are free to redistribute this code under the terms of the
 GNU General Public License, version 2, or (at your option) any later version.
 EOF
 
-my ($opt_echo, $opt_force, $opt_extra, $opt_posix, $opt_early_fail);
+my ($opt_echo, $opt_force, $opt_extra, $opt_posix, $opt_early_fail, $opt_lint);
 my ($opt_help, $opt_version);
 my @filenames;
 
@@ -67,6 +67,7 @@ GetOptions(
     "help|h"       => \$opt_help,
     "version|v"    => \$opt_version,
     "newline|n"    => \$opt_echo,
+    "lint|l"       => \$opt_lint,
     "force|f"      => \$opt_force,
     "extra|x"      => \$opt_extra,
     "posix|p"      => \$opt_posix,
@@ -545,7 +546,12 @@ sub output_explanation {
         # bashisms present
         $issues = 1;
     } else {
-        warn "possible bashism in $filename line $. ($explanation):\n$line\n";
+        if ($opt_lint) {
+            print "$filename:$.:1: warning: possible bashism; $explanation\n";
+        } else {
+            warn
+              "possible bashism in $filename line $. ($explanation):\n$line\n";
+        }
         if ($opt_early_fail) {
             exit 1;
         }
@@ -643,7 +649,7 @@ sub init_hashes {
         qr'\[\s+[^\]]+\s+==\s'                   => q<should be 'b = a'>,
         qr'\s\|\&'                               => q<pipelining is not POSIX>,
         qr'[^\\\$]\{([^\s\\\}]*?,)+[^\\\}\s]*\}' => q<brace expansion>,
-        qr'\{\d+\.\.\d+(?:\.\.\d+)?\}' =>
+        qr'\{\d+\.\.\d+(?:\.\.\d+)?\}'           =>
           q<brace expansion, {a..b[..c]}should be $(seq a [c] b)>,
         qr'(?i)\{[a-z]\.\.[a-z](?:\.\.\d+)?\}' => q<brace expansion>,
         qr'(?:^|\s+)\w+\[\d+\]='               => q<bash arrays, H[0]>,
@@ -719,7 +725,7 @@ qr'(?:^|\s)(?<func>function\s)?\s*(?:[^<>\(\)\[\]\{\};|\s]*[^<>\(\)\[\]\{\};|\s\
         $LEADIN
           . qr'(?:exit|return)\s+--' =>
           q<'exit --' should be 'exit' (idem for return)>,
-        $LEADIN . qr'hash(\s|\Z)' => q<hash>,
+        $LEADIN . qr'hash(\s|\Z)'                    => q<hash>,
         qr'(?:[:=\s])~(?:[+-]|[+-]?\d+)(?:[/\s]|\Z)' =>
           q<non-standard tilde expansion>,
     );
@@ -728,13 +734,13 @@ qr'(?:^|\s)(?<func>function\s)?\s*(?:[^<>\(\)\[\]\{\};|\s]*[^<>\(\)\[\]\{\};|\s\
         qr'\$\[[^][]+\]' => q<'$[' should be '$(('>,
         qr'\$\{(?:\w+|@|\*)\:(?:\d+|\$\{?\w+\}?)+(?::(?:\d+|\$\{?\w+\}?)+)?\}'
           => q<${foo:3[:1]}>,
-        qr'\$\{!\w+[\@*]\}' => q<${!prefix[*|@]>,
-        qr'\$\{!\w+\}'      => q<${!name}>,
+        qr'\$\{!\w+[\@*]\}'                  => q<${!prefix[*|@]>,
+        qr'\$\{!\w+\}'                       => q<${!name}>,
         qr'\$\{(?:\w+|@|\*)([,^]{1,2}.*?)\}' =>
           q<${parm,[,][pat]} or ${parm^[^][pat]}>,
         qr'\$\{[@*]([#%]{1,2}.*?)\}' => q<${[@|*]#[#]pat} or ${[@|*]%[%]pat}>,
         qr'\$\{#[@*]\}'              => q<${#@} or ${#*}>,
-        qr'\$\{(?:\w+|@|\*)(/.+?){1,2}\}' => q<${parm/?/pat[/str]}>,
+        qr'\$\{(?:\w+|@|\*)(/.+?){1,2}\}'      => q<${parm/?/pat[/str]}>,
         qr'\$\{\#?\w+\[.+\](?:[/,:#%^].+?)?\}' =>
           q<bash arrays, ${name[0|*|@]}>,
         qr'\$\{?RANDOM\}?\b'          => q<$RANDOM>,


### PR DESCRIPTION
Debian has dropped `devscripts_2.21.4.tar.xz` from http://ftp.debian.org/debian/pool/main/d/devscripts, there is `devscripts_2.21.7.tar.xz` now.
