### PR TITLE
make CI actions more usable for private repos

### DIFF
--- a/aws-proofs/README.md
+++ b/aws-proofs/README.md
@@ -21,6 +21,7 @@ automatically spins up and terminates the corresponding AWS instance.
 - `isa-branch`:  which branch of the Isabelle repo (e.g. `ts-2020`, default as in
                  manifest)
 - `manifest`:    which manifest file (e.g. `devel.xml`, `mcs.xml`, `default.xml`)
+- `cache_bucket`: name of the AWS S3 bucket to use for isabelle images (optional).
 - `cache_read`:  whether to read Isabelle images from cache. Default true. Set to
                  empty string to skip.
 - `cache_write`: whether to write Isabelle images to cache. Default true. Set to

--- a/aws-proofs/README.md
+++ b/aws-proofs/README.md
@@ -31,6 +31,7 @@ automatically spins up and terminates the corresponding AWS instance.
 - `skip_dups`:   skip duplicated proofs (default true).
                  Set to empty string to also run proofs that are already checked
                  in other proof sessions.
+- `token`:       GitHub PA token to authenticate for private repos (optional)
 
 ## Environment
 

--- a/aws-proofs/action.yml
+++ b/aws-proofs/action.yml
@@ -28,6 +28,10 @@ inputs:
   cache_name:
     description: 'Custom cache name. Should contain at least L4V_ARCH.'
     required: false
+  cache_bucket:
+    description: 'Custom S3 bucket for the isabelle image cache.'
+    default: 'isabelle-images'
+    required: false
   skip_dups:
     description: 'Skip duplicate proofs. Set to empty string to run duplicate proofs'
     default: "1"

--- a/aws-proofs/action.yml
+++ b/aws-proofs/action.yml
@@ -38,6 +38,9 @@ inputs:
   xml:
     description: 'Input manifest with specific repo revisions to test (optional)'
     required: false
+  token:
+    description: 'Github token for repo read access'
+    required: false
   action_name:
     description: 'internal -- do not use'
     required: false

--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -68,6 +68,7 @@ ssh -o SendEnv=INPUT_CI_BRANCH \
     -o SendEnv=INPUT_MANIFEST \
     -o SendEnv=INPUT_ISA_BRANCH \
     -o SendEnv=INPUT_SESSION \
+    -o SendEnv=INPUT_CACHE_BUCKET \
     -o SendEnv=INPUT_CACHE_NAME \
     -o SendEnv=INPUT_CACHE_READ \
     -o SendEnv=INPUT_CACHE_WRITE \

--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -72,6 +72,7 @@ ssh -o SendEnv=INPUT_CI_BRANCH \
     -o SendEnv=INPUT_CACHE_READ \
     -o SendEnv=INPUT_CACHE_WRITE \
     -o SendEnv=INPUT_SKIP_DUPS \
+    -o SendEnv=INPUT_TOKEN \
     -o SendEnv=INPUT_XML \
     -o SendEnv=INPUT_EXTRA_PRS \
     -o SendEnv=GITHUB_REPOSITORY \

--- a/aws-proofs/vm-steps.sh
+++ b/aws-proofs/vm-steps.sh
@@ -67,7 +67,7 @@ if [ -n "${INPUT_CACHE_READ}" ]
 then
   echo "Getting image cache ${CACHE_NAME}"
   # it's Ok for this command to fail, cache might not yet exist
-  aws s3 cp "s3://isabelle-images/${CACHE_NAME}.tar.xz" - | tar -C ~/.isabelle -vJx || true
+  aws s3 cp "s3://${INPUT_CACHE_BUCKET}/${CACHE_NAME}.tar.xz" - | tar -C ~/.isabelle -vJx || true
 else
   echo "Skipping image cache read"
 fi
@@ -105,7 +105,7 @@ then
   echo "Writing image cache ${CACHE_NAME}"
   # compress not too much; s3 upload is fast and compression winnings are meager
   tar -C ~/.isabelle -vc heaps/ | xz -T0 -3 - | \
-    aws s3 cp - "s3://isabelle-images/${CACHE_NAME}.tar.xz"
+    aws s3 cp - "s3://${INPUT_CACHE_BUCKET}/${CACHE_NAME}.tar.xz"
 else
   echo "Skipping image cache write"
 fi

--- a/license-check/README.md
+++ b/license-check/README.md
@@ -26,7 +26,7 @@ just calls this script.
 
 ## Arguments
 
-None
+- `token`: GitHub PA token to authenticate for private repos (optional)
 
 ## Example
 

--- a/license-check/action.yml
+++ b/license-check/action.yml
@@ -7,6 +7,9 @@ description: 'Runs the FSFE reuse license tool'
 author: Gerwin Klein <kleing@unsw.edu.au>
 
 inputs:
+  token:
+    description: 'GitHub token for read access to repository'
+    required: false
   action_name:
     description: 'internal -- do not use'
     required: false

--- a/link-check/README.md
+++ b/link-check/README.md
@@ -31,6 +31,7 @@ No arguments are required. The following are available.
 * `doc_root`: Document root for absolute links
 * `num_requests`: Maximum number of concurrent requests
 * `verbose`: Print more information if set (default unset)
+* `token`: GitHub PA token to authenticate for private repos
 
 ## Example
 

--- a/link-check/action.yml
+++ b/link-check/action.yml
@@ -26,6 +26,9 @@ inputs:
   num_requests:
     description: 'Maximum number of concurrent requests'
     required: false
+  token:
+    description: 'GitHub token for read access to repository'
+    required: false
   verbose:
     description: 'Print more information if set (default unset)'
     required: false

--- a/scripts/checkout.sh
+++ b/scripts/checkout.sh
@@ -6,10 +6,18 @@
 
 # Clones target repo (of push or pull request) into current directory
 
-: ${REPO_URL:="https://github.com/${GITHUB_REPOSITORY}.git"}
+: ${REPO_PATH:="github.com/${GITHUB_REPOSITORY}.git"}
 : ${DEPTH:=1}
 
-echo "Cloning ${REPO_URL}@${GITHUB_REF}"
+if [ -n "${INPUT_TOKEN}" ]
+then
+  REPO_URL="https://${INPUT_TOKEN}@${REPO_PATH}"
+  REPO_PATH="token@${REPO_PATH}"
+else
+  REPO_URL="https://${REPO_PATH}"
+fi
+
+echo "Cloning ${REPO_PATH}@${GITHUB_REF}"
 git init -q .
 git remote add origin ${REPO_URL}
 git fetch -q --no-tags --depth ${DEPTH} origin +${GITHUB_REF}:refs/heads/test-revision

--- a/scripts/fetch-branch.sh
+++ b/scripts/fetch-branch.sh
@@ -13,7 +13,15 @@ then
   # Assumes a repo manifest checkout, and current working dir in the repo
   # to fetch the branch for.
 
-  URL="https://github.com/${GITHUB_REPOSITORY}.git"
+  REPO_PATH="github.com/${GITHUB_REPOSITORY}.git"
+
+  if [ -n "${INPUT_TOKEN}" ]
+  then
+    URL="https://${INPUT_TOKEN}@${REPO_PATH}"
+    REPO_PATH="token@${REPO_PATH}"
+  else
+    URL="https://${REPO_PATH}"
+  fi
 
   # if an explicit SHA is set as INPUT (e.g. for pull request target), prefer that over GITHUB_REF
   if [ -n "${INPUT_SHA}" ]
@@ -25,7 +33,7 @@ then
     FETCH=${REF}:${REF}
   fi
 
-  echo "Fetching ${REF} from ${URL}"
+  echo "Fetching ${REF} from ${REPO_PATH}"
   git fetch -q --depth 1 ${URL} ${FETCH}
   git checkout -q ${REF}
   if [ -n "${BRANCH_NAME}" ]

--- a/scripts/fetch-extra-prs.sh
+++ b/scripts/fetch-extra-prs.sh
@@ -16,11 +16,20 @@ then
     REPO=${PR%#*}
     ID=${PR#*#}
 
-    URL="https://github.com/${REPO}.git"
+    REPO_PATH="github.com/${REPO}.git"
+
+    if [ -n "${INPUT_TOKEN}" ]
+    then
+      URL="https://${INPUT_TOKEN}@${REPO_PATH}"
+      REPO_PATH="token@${REPO_PATH}"
+    else
+      URL="https://${REPO_PATH}"
+    fi
+
     REF="refs/pull/${ID}/head"
 
     cd $(repo-util path ${REPO})
-    echo "Fetching ${REF} from ${URL}"
+    echo "Fetching ${REF} from ${REPO_PATH}"
     git fetch -q --depth 1 ${URL} ${REF}:${REF}
     git checkout -q ${REF}
     cd - > /dev/null

--- a/scripts/repo-util
+++ b/scripts/repo-util
@@ -135,7 +135,9 @@ def path_of(gh_repo: str, projects: dict) -> str:
     """Get the path of a given repo in projects dict.
     Accepts GITHUB_REPOSITORY-style references like seL4/seL4 (for repo "seL4")"""
     repo = gh_repo.split('/')[-1]
-    return projects.get(repo.lower(), (None, None))[0]
+    # remove optional -priv suffix for private forks
+    repo = removesuffix(repo.lower(), '-priv')
+    return projects.get(repo, (None, None))[0]
 
 
 # main program:


### PR DESCRIPTION
This PR adds some infrastructure for proof CI actions to be reused in private clones of the main seL4 repositories. In particular:

- allow a `-priv` suffix in the repo name for path recognition
- accept optional auth token in checkout and fetching scripts
- use the above in a few example actions (to be expanded on demand where useful)
- accept optional S3 bucket name for AWS isabelle image cache
