### PR TITLE
standalone-kernel: support AARCH64 config

### DIFF
--- a/standalone-kernel/README.md
+++ b/standalone-kernel/README.md
@@ -22,7 +22,7 @@ The entry point is the script [`compile_kernel.sh`](compile_kernel.sh/)
 ### ARCH
 
 The `ARCH` input is the architecture tag that selects the configuration to be compiled.
-Valid values are `ARM`, `ARM_HYP`, `RISCV64`, `X64`.
+Valid values are `ARM`, `ARM_HYP`, `AARCH64`, `RISCV64`, `X64`.
 
 ### COMPILER
 
@@ -44,7 +44,7 @@ standalone_kernel:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ARM, ARM_HYP, RISCV64, X64]
+        arch: [ARM, ARM_HYP, AARCH64, RISCV64, X64]
         compiler: [gcc, llvm]
         exclude:
           # llvm RISCV64 compilation is not currently supported
@@ -56,5 +56,4 @@ standalone_kernel:
       with:
         ARCH: ${{ matrix.arch }}
         COMPILER: ${{ matrix.compiler }}
-        PYTHON: ${{ matrix.python }}
 ```

--- a/standalone-kernel/action.yml
+++ b/standalone-kernel/action.yml
@@ -10,7 +10,7 @@ author: Luke Mondy <luke.mondy@data61.csiro.au>
 
 inputs:
   ARCH:
-    description: 'Architecture to test. One of ARM, ARM_HYP, RISCV64, X64'
+    description: 'Architecture to test. One of ARM, ARM_HYP, AARCH64, RISCV64, X64'
     required: true
 
   COMPILER:

--- a/standalone-kernel/compile_kernel.sh
+++ b/standalone-kernel/compile_kernel.sh
@@ -29,6 +29,19 @@ case $INPUT_ARCH in
                 exit 1
         esac
         ;;
+    AARCH64)
+        case $INPUT_COMPILER in
+            gcc)
+                extra_config="${extra_config} -DAARCH64=TRUE"
+                ;;
+            llvm)
+                extra_config="${extra_config} -DTRIPLE=aarch64-linux-gnu"
+                ;;
+            *)
+                echo "Unknown input compiler"
+                exit 1
+        esac
+        ;;
     RISCV64)
         extra_config="${extra_config} -DRISCV64=TRUE"
         ;;


### PR DESCRIPTION
This (= standalone compilation for the kernel) is one more check that should enabled in the seL4 repo for the AARCH64_verified config.