### PR TITLE
Update checkbashisms to v2.22.1

### DIFF
--- a/bashisms/README.md
+++ b/bashisms/README.md
@@ -39,6 +39,6 @@ jobs:
 ### Maintenance
 
 The `checkbashism` script in `../scripts` is directly extracted from
-<https://deb.debian.org/debian/pool/main/d/devscripts/devscripts_2.21.7.tar.xz>.
+<https://deb.debian.org/debian/pool/main/d/devscripts/devscripts_2.22.1.tar.xz>.
 Installing it via `apt-get` takes forever, because the rest of the devscripts
 has lots of dependencies.


### PR DESCRIPTION
Debian has dropped `devscripts_2.21.7.tar.xz` and uses `devscripts_2.22.1.tar.xz` now. The `checkbashisms` script itself has not
changed. See http://ftp.debian.org/debian/pool/main/d/devscripts/