### PR TITLE
repo-checkout: make sure PyGithub is available

### DIFF
--- a/repo-checkout/steps.sh
+++ b/repo-checkout/steps.sh
@@ -14,6 +14,8 @@ curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
 chmod a+x ~/bin/repo
 PATH=~/bin:$PATH
 
+pip3 install -U PyGithub
+
 echo "::endgroup::"
 
 echo "::group::Repo checkout"


### PR DESCRIPTION
So far this action had only been used in deployment workflows where no
pull-request relevant code was running (on push actions only). Since we
are now using it on seL4bench PRs, we need to make sure the
dependencies for the python PR info code are available.

Fixes seL4/sel4bench#24
