### PR TITLE
thylint: missing files are not an error in diff-only mode

### DIFF
--- a/thylint/thylint.py
+++ b/thylint/thylint.py
@@ -364,8 +364,9 @@ def main():
             try:
                 matches += lint_file(file, matchers)
             except IOError:
-                print('IO error for file "{0}"'.format(file), file=sys.stderr)
-                failures = True
+                if not args.diff_only:
+                    print('IO error for file "{0}"'.format(file), file=sys.stderr)
+                    failures = True
 
     if args.diff_only:
         matches = filter_matches(matches, args.diff_only[0], args.files)


### PR DESCRIPTION
The diff list we get from git will include deleted files, which will then turn into IOErrors here. If we're in that mode, ignore missing files -- only report them when they are given explicitly.
