### PR TITLE
repo-checkout: bash script start settings

### DIFF
--- a/repo-checkout/steps.sh
+++ b/repo-checkout/steps.sh
@@ -1,11 +1,9 @@
-#!/bin/bash
+#!/bin/bash -eu
 #
 # Copyright 2021, Proofcraft Pty Ltd
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
-
-set -e
 
 echo "::group::Setting up"
 


### PR DESCRIPTION
Ensure the script is started in a mode where errors or undefined variables cause an exit.
