### PR TITLE
aws-proofs: export C graph-lang

### DIFF
--- a/aws-proofs/README.md
+++ b/aws-proofs/README.md
@@ -33,6 +33,7 @@ automatically spins up and terminates the corresponding AWS instance.
 - `skip_dups`:   skip duplicated proofs (default true).
                  Set to empty string to also run proofs that are already checked
                  in other proof sessions.
+- `simpl_export`: Whether to save C graph-lang for binary verification (optional).
 - `ci_branch`:   ci-actions branch to use on AWS VM (optional).
 - `token`:       GitHub PA token to authenticate for private repos (optional)
 

--- a/aws-proofs/README.md
+++ b/aws-proofs/README.md
@@ -18,9 +18,10 @@ automatically spins up and terminates the corresponding AWS instance.
 - `session`:     which session to run (e.g. `CRefine` or `ASpec`, or `ASpec
                  CRefine`, i.e. a space-separated string). Runs all sessions if
                  unset.
-- `isa-branch`:  which branch of the Isabelle repo (e.g. `ts-2020`, default as in
+- `isa_branch`:  which branch of the Isabelle repo (e.g. `ts-2020`, default as in
                  manifest)
 - `manifest`:    which manifest file (e.g. `devel.xml`, `mcs.xml`, `default.xml`)
+- `xml`:         input manifest with specific repo revisions to test (optional).
 - `cache_bucket`: name of the AWS S3 bucket to use for isabelle images (optional).
 - `cache_read`:  whether to read Isabelle images from cache. Default true. Set to
                  empty string to skip.

--- a/aws-proofs/README.md
+++ b/aws-proofs/README.md
@@ -33,6 +33,7 @@ automatically spins up and terminates the corresponding AWS instance.
 - `skip_dups`:   skip duplicated proofs (default true).
                  Set to empty string to also run proofs that are already checked
                  in other proof sessions.
+- `ci_branch`:   ci-actions branch to use on AWS VM (optional).
 - `token`:       GitHub PA token to authenticate for private repos (optional)
 
 ## Environment

--- a/aws-proofs/action.yml
+++ b/aws-proofs/action.yml
@@ -42,6 +42,13 @@ inputs:
   xml:
     description: 'Input manifest with specific repo revisions to test (optional)'
     required: false
+  simpl_export:
+    description: |
+      Whether to export the C graph-lang for binary verification.
+      Set to any non-empty string to enable.
+      Ignored for architectures that don't support SimplExportAndRefine,
+      so it's safe to set across a matrix.
+    required: false
   ci_branch:
     description: 'ci-actions branch to use on AWS VM (optional)'
     default: 'master'

--- a/aws-proofs/action.yml
+++ b/aws-proofs/action.yml
@@ -42,6 +42,10 @@ inputs:
   xml:
     description: 'Input manifest with specific repo revisions to test (optional)'
     required: false
+  ci_branch:
+    description: 'ci-actions branch to use on AWS VM (optional)'
+    default: 'master'
+    required: false
   token:
     description: 'Github token for repo read access'
     required: false

--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -73,6 +73,7 @@ ssh -o SendEnv=INPUT_CI_BRANCH \
     -o SendEnv=INPUT_CACHE_READ \
     -o SendEnv=INPUT_CACHE_WRITE \
     -o SendEnv=INPUT_SKIP_DUPS \
+    -o SendEnv=INPUT_SIMPL_EXPORT \
     -o SendEnv=INPUT_TOKEN \
     -o SendEnv=INPUT_XML \
     -o SendEnv=INPUT_EXTRA_PRS \
@@ -82,7 +83,7 @@ ssh -o SendEnv=INPUT_CI_BRANCH \
     -o SetEnv=GITHUB_WORKSPACE=/home/test-runner \
     test-runner@${IP} ./run
 
-# leave logs on GitHub runner for later artifact upload
-scp test-runner@${IP}:logs.tar.xz .
+# leave artifacts on GitHub runner for later upload
+scp -r test-runner@${IP}:logs.tar.xz test-runner@${IP}:artifacts .
 
 # instance termination is in post-steps.sh

--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -61,7 +61,7 @@ fi
 
 echo "::endgroup::"
 
-export INPUT_CI_BRANCH=master
+export INPUT_CI_BRANCH=${INPUT_CI_BRANCH:-master}
 
 ssh -o SendEnv=INPUT_CI_BRANCH \
     -o SendEnv=INPUT_L4V_ARCH \


### PR DESCRIPTION
When SimplExportAndRefine is performed during an AWS proof run, save the exported graph-lang for use in binary verification.