### PR TITLE
aws-proofs: more support for binary verification

### DIFF
--- a/aws-proofs/README.md
+++ b/aws-proofs/README.md
@@ -15,6 +15,7 @@ automatically spins up and terminates the corresponding AWS instance.
 
 - `L4V_ARCH` (required): which architecture to run the proofs for. One of `ARM`,
                  `ARM_HYP`, `RISCV64`, `X64`
+- `L4V_FEATURES`: Optional kernel features to test. Either `MCS` or empty.
 - `session`:     which session to run (e.g. `CRefine` or `ASpec`, or `ASpec
                  CRefine`, i.e. a space-separated string). Runs all sessions if
                  unset.
@@ -28,8 +29,9 @@ automatically spins up and terminates the corresponding AWS instance.
 - `cache_write`: whether to write Isabelle images to cache. Default true. Set to
                  empty string to skip.
 - `cache_name`:  optional custom name for image cache. Should at least contain
-                 `L4V_ARCH`. Default is distinguishes separate caches for separate
-                 values of `isa-branch`, `manifest`, and `L4V_ARCH`.
+                 `L4V_ARCH`. The default results in separate caches for distinct
+                 combinations of `isa-branch`, `manifest`, `L4V_ARCH`,
+                 and `L4V_FEATURES`.
 - `skip_dups`:   skip duplicated proofs (default true).
                  Set to empty string to also run proofs that are already checked
                  in other proof sessions.

--- a/aws-proofs/README.md
+++ b/aws-proofs/README.md
@@ -35,7 +35,6 @@ automatically spins up and terminates the corresponding AWS instance.
 - `skip_dups`:   skip duplicated proofs (default true).
                  Set to empty string to also run proofs that are already checked
                  in other proof sessions.
-- `simpl_export`: Whether to save C graph-lang for binary verification (optional).
 - `ci_branch`:   ci-actions branch to use on AWS VM (optional).
 - `token`:       GitHub PA token to authenticate for private repos (optional)
 

--- a/aws-proofs/action.yml
+++ b/aws-proofs/action.yml
@@ -11,6 +11,9 @@ inputs:
   L4V_ARCH:
     description: 'Architecture to test. One of ARM, ARM_HYP, RISCV64, X64'
     required: true
+  L4V_FEATURES:
+    description: 'Kernel features to test (optional). Either MCS or unset.'
+    requred: false
   session:
     description: 'Which proof session to run (space-separated string)'
     required: false

--- a/aws-proofs/action.yml
+++ b/aws-proofs/action.yml
@@ -45,13 +45,6 @@ inputs:
   xml:
     description: 'Input manifest with specific repo revisions to test (optional)'
     required: false
-  simpl_export:
-    description: |
-      Whether to export the C graph-lang for binary verification.
-      Set to any non-empty string to enable.
-      Ignored for architectures that don't support SimplExportAndRefine,
-      so it's safe to set across a matrix.
-    required: false
   ci_branch:
     description: 'ci-actions branch to use on AWS VM (optional)'
     default: 'master'

--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -65,6 +65,7 @@ export INPUT_CI_BRANCH=${INPUT_CI_BRANCH:-master}
 
 ssh -o SendEnv=INPUT_CI_BRANCH \
     -o SendEnv=INPUT_L4V_ARCH \
+    -o SendEnv=INPUT_L4V_FEATURES \
     -o SendEnv=INPUT_MANIFEST \
     -o SendEnv=INPUT_ISA_BRANCH \
     -o SendEnv=INPUT_SESSION \

--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -74,7 +74,6 @@ ssh -o SendEnv=INPUT_CI_BRANCH \
     -o SendEnv=INPUT_CACHE_READ \
     -o SendEnv=INPUT_CACHE_WRITE \
     -o SendEnv=INPUT_SKIP_DUPS \
-    -o SendEnv=INPUT_SIMPL_EXPORT \
     -o SendEnv=INPUT_TOKEN \
     -o SendEnv=INPUT_XML \
     -o SendEnv=INPUT_EXTRA_PRS \

--- a/aws-proofs/vm-steps.sh
+++ b/aws-proofs/vm-steps.sh
@@ -53,13 +53,16 @@ repo-util hashes
 echo "Setting up Isabelle components"
 isabelle/bin/isabelle components -a
 
+export L4V_ARCH=${INPUT_L4V_ARCH}
+export L4V_FEATURES=${INPUT_L4V_FEATURES}
+
 CACHE_NAME=${INPUT_CACHE_NAME}
 if [ -z "${CACHE_NAME}" ]
 then
   # construct default cache name
   BRANCH=${INPUT_ISA_BRANCH:-default}
   MANIFEST=${INPUT_MANIFEST:-devel}
-  CACHE_NAME="${GITHUB_REPOSITORY}-${BRANCH}-${MANIFEST}-${INPUT_L4V_ARCH}"
+  CACHE_NAME="${GITHUB_REPOSITORY}-${BRANCH}-${MANIFEST}-${L4V_ARCH}${L4V_FEATURES:+-${L4V_FEATURES}}"
 fi
 
 echo "::group::Cache"
@@ -77,7 +80,6 @@ echo "::endgroup::"
 
 echo "::group::Proof run"
 
-export L4V_ARCH=${INPUT_L4V_ARCH}
 export SKIP_DUPLICATED_PROOFS=${INPUT_SKIP_DUPS}
 
 FAIL=0


### PR DESCRIPTION
Two changes:
- Simplify SimplExport artefact handling that was introduced in a previous pull request.
- Add support for `L4V_FEATURES`.

I'm happy to split the PR if you want to consider them separately.