### PR TITLE
add git-credentials-setup action

### DIFF
--- a/.stylefilter
+++ b/.stylefilter
@@ -6,6 +6,7 @@ aws-proofs/steps.sh
 scripts/setup-hw-ssh.sh
 l4v-deploy/steps.sh
 manifest-deploy/steps.sh
+git-https-credentials-setup/steps.sh
 
 # uses bash nullglob, which we also do want:
 aws-proofs/vm-steps.sh

--- a/git-https-credentials-setup/README.md
+++ b/git-https-credentials-setup/README.md
@@ -1,0 +1,46 @@
+<!--
+     Copyright 2022, Kry10 Limited
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Set up credentials for HTTPS access to GitHub repositories
+
+Configures git to use `git-credential-store`, and populates the credential
+store for the given GitHub repositories.
+
+Note that this stores credentials in plain text in a file which will be visible
+to the workflow runner user in all steps between this action and its clean-up
+phase. The clean-up phase removes the file containing the credentials.
+
+# Inputs
+
+The following inputs are required, unless marked optional.
+
+- `username`: The username to use for HTTPS access, e.g. `seL4-ci`.
+- `token`:    A personal access token (PAT) owned by the given user, with the
+              required access to the given GitHub repositories.
+- `repos`:    A space-separated list of GitHub repositories, given as
+              organisation/repo pairs, e.g. `seL4/seL4 seL4/l4v`.
+- `store_id`: Optional. A unique identifier that is added as a suffix to the
+              name of the credential file. May be useful if multiple instances
+              of this action need to be nested.
+
+## Example
+
+```yml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Git credentials
+      uses: seL4/ci-actions/git-credentials-setup@master
+      with:
+        username: 'seL4-ci'
+        token: ${{ secrets.PRIV_REPO_TOKEN }}
+        repos: 'seL4/seL4 seL4/l4v'
+    - name: Push branches
+      run: |
+        (cd seL4 && git push)
+        (cd l4v && git push)
+```

--- a/git-https-credentials-setup/action.yml
+++ b/git-https-credentials-setup/action.yml
@@ -1,0 +1,33 @@
+# Copyright 2022, Kry10 Limited
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: 'GitHub HTTPS Credentials Setup'
+description: |
+  Configures Git credential store to access GitHub repositories over HTTPS.
+author: Matthew Brecknell <matt@kry10.com>
+
+inputs:
+  username:
+    description: |
+      The GitHub username to use for HTTPS access, e.g. `seL4-ci`.
+    required: true
+  token:
+    description: |
+      A personal access token (PAT) owned by the given user, with the
+      required access to the given GitHub repositories.
+    required: true
+  repos:
+    description: |
+      A space-separated list of GitHub repositories, given as
+      organisation/repo pairs, e.g. `seL4/seL4 seL4/l4v`.
+    required: true
+  store_id:
+    description: |
+      An identifier that can be used to distinguish multiple uses of
+      this action in a job.
+
+runs:
+  using: 'node12'
+  main: '../js/index.js'
+  post: '../js/post.js'

--- a/git-https-credentials-setup/action.yml
+++ b/git-https-credentials-setup/action.yml
@@ -26,6 +26,7 @@ inputs:
     description: |
       An identifier that can be used to distinguish multiple uses of
       this action in a job.
+    required: false
 
 runs:
   using: 'node12'

--- a/git-https-credentials-setup/post.sh
+++ b/git-https-credentials-setup/post.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Copyright 2022, Kry10 Limited
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+set -e
+
+GIT_CREDENTIALS="${HOME}/.git-credentials-${INPUT_STORE_ID:-seL4}"
+
+echo "::group::Removing Git credentials"
+
+for REPO in "${INPUT_REPOS}"; do
+  git config --global --remove-section "credential.\"https://github.com/${REPO}\""
+done
+
+rm -f "${GIT_CREDENTIALS}"
+
+echo "::endgroup::"

--- a/git-https-credentials-setup/steps.sh
+++ b/git-https-credentials-setup/steps.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright 2022, Kry10 Limited
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+set -e
+
+GIT_CREDENTIALS="${HOME}/.git-credentials-${INPUT_STORE_ID:-seL4}"
+
+if [ -e "${GIT_CREDENTIALS}" ]; then
+  echo "error: ${GIT_CREDENTIALS} already exists."
+  exit 1
+fi
+
+echo "::group::Storing credentials"
+
+touch "${GIT_CREDENTIALS}"
+chmod 0600 "${GIT_CREDENTIALS}"
+
+for REPO in ${INPUT_REPOS}; do
+  cat <<< "https://${INPUT_USERNAME}:${INPUT_TOKEN}@github.com/${REPO}"
+  echo
+done >> "${GIT_CREDENTIALS}"
+
+echo "::endgroup::"
+
+echo "::group::Configuring git to use stored credentials"
+
+for REPO in ${INPUT_REPOS}; do
+   git config --global \
+     "credential.\"https://github.com/${REPO}\".helper" \
+     "store --file=\"${GIT_CREDENTIALS}\""
+done
+
+echo "::endgroup::"

--- a/git-https-credentials-setup/steps.sh
+++ b/git-https-credentials-setup/steps.sh
@@ -7,6 +7,8 @@
 
 set -e
 
+echo "::group::Creating credentials file"
+
 GIT_CREDENTIALS="${HOME}/.git-credentials-${INPUT_STORE_ID:-seL4}"
 
 if [ -e "${GIT_CREDENTIALS}" ]; then
@@ -14,10 +16,12 @@ if [ -e "${GIT_CREDENTIALS}" ]; then
   exit 1
 fi
 
-echo "::group::Storing credentials"
-
 touch "${GIT_CREDENTIALS}"
 chmod 0600 "${GIT_CREDENTIALS}"
+
+echo "::endgroup::"
+
+echo "::group::Storing credentials"
 
 for REPO in ${INPUT_REPOS}; do
   cat <<< "https://${INPUT_USERNAME}:${INPUT_TOKEN}@github.com/${REPO}"


### PR DESCRIPTION
This action uses git-credentials-store to store credentials for HTTPS access to GitHub repositories.

@lsf37 I'm not sure this is a good idea, so I don't mind if you wan to reject it. Compared to an ssh-agent, it has the advantage that in principle, you can use different credentials for different repos (though I concede that we don't actually need that). But it has the disadvantage that the sensitive material is exposed to all subsequent steps. An ssh-agent makes it a bit harder to extract the actual keys (but maybe it's still possible?). 🤷

I'm leaning towards not doing this, but I thought I'd run it past you before I delete it.