### PR TITLE
aws-proofs: fix typo in `L4V_FEATURES`

### DIFF
--- a/aws-proofs/action.yml
+++ b/aws-proofs/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: true
   L4V_FEATURES:
     description: 'Kernel features to test (optional). Either MCS or unset.'
-    requred: false
+    required: false
   session:
     description: 'Which proof session to run (space-separated string)'
     required: false


### PR DESCRIPTION
Misspelled `required`.

Signed-off-by: Matthew Brecknell <matt@kry10.com>