### PR TITLE
aws-proofs: run 2 sessions in parallel

### DIFF
--- a/aws-proofs/vm-steps.sh
+++ b/aws-proofs/vm-steps.sh
@@ -88,9 +88,9 @@ FAIL=0
 L4V_DIR="$PWD/l4v"
 if [ -n "${INPUT_SESSION}" ]
 then
-  do_run_tests() { (cd "$L4V_DIR" && ./run_tests -v ${INPUT_SESSION} "$@"); }
+  do_run_tests() { (cd "$L4V_DIR" && ./run_tests -j 2 ${INPUT_SESSION} "$@"); }
 else
-  do_run_tests() { (cd "$L4V_DIR" && ./run_tests -v -x AutoCorresSEL4 "$@"); }
+  do_run_tests() { (cd "$L4V_DIR" && ./run_tests -j 2 -x AutoCorresSEL4 "$@"); }
 fi
 
 do_run_tests || FAIL=1


### PR DESCRIPTION
It's not entirely clear if this will really speed things up. If the VM has n nominal cores, this will include hyper-threading, so Isabelle will pick n/2 threads to run. With `-j 2` and without further changes to settings, we will now potentially have all threads on the CPU busy, which would result in slower single sessions.

But: the VMs have a fairly high CPU count (16 threads), and most sessions will not be able to use the full 8 cores all of the time, so there should be significant savings from not being blocked on long sessions.

