### PR TITLE
aws-proofs: remove hard-coded of session exclusion

### DIFF
--- a/aws-proofs/vm-steps.sh
+++ b/aws-proofs/vm-steps.sh
@@ -86,12 +86,7 @@ export SKIP_DUPLICATED_PROOFS=${INPUT_SKIP_DUPS}
 FAIL=0
 
 L4V_DIR="$PWD/l4v"
-if [ -n "${INPUT_SESSION}" ]
-then
-  do_run_tests() { (cd "$L4V_DIR" && ./run_tests -j 2 ${INPUT_SESSION} "$@"); }
-else
-  do_run_tests() { (cd "$L4V_DIR" && ./run_tests -j 2 -x AutoCorresSEL4 "$@"); }
-fi
+do_run_tests() { (cd "$L4V_DIR" && ./run_tests -j 2 ${INPUT_SESSION} "$@"); }
 
 do_run_tests || FAIL=1
 


### PR DESCRIPTION
Excluding or not excluding the large `AutoCorresSEL4` session should happen at the call site. It turns out that we only really want this on the testboard, and all other sessions needed to artificially providea parameter to remove the exclusion.
