### PR TITLE
hw-builds: make it easier to identify workflow

### DIFF
--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -400,7 +400,9 @@ def get_machine(req):
 
 
 def job_key():
-    return os.environ.get('GITHUB_RUN_ID') + "-" + \
+    return os.environ.get('GITHUB_REPOSITORY') + "-" + \
+        os.environ.get('GITHUB_WORKFLOW') + "-" + \
+        os.environ.get('GITHUB_RUN_ID') + "-" + \
         os.environ.get('GITHUB_JOB') + "-" + \
         os.environ.get('INPUT_INDEX', '$0')[1:]
 


### PR DESCRIPTION
Add repo + workflow name to the machine queue key so that it is easier to identify where the job is coming from when things go wrong.
