### PR TITLE
aws-proofs: show proof results directly

### DIFF
--- a/aws-proofs/vm-steps.sh
+++ b/aws-proofs/vm-steps.sh
@@ -79,8 +79,6 @@ echo "::endgroup::"
 
 echo "::endgroup::"
 
-echo "::group::Proof run"
-
 export SKIP_DUPLICATED_PROOFS=${INPUT_SKIP_DUPS}
 
 FAIL=0
@@ -95,8 +93,6 @@ echo "Stats:"
 ~/ci-actions/aws-proofs/kernel-sloc.sh
 echo ""
 cd l4v; ~/ci-actions/aws-proofs/sorry-count.sh; cd ..
-
-echo "::endgroup::"
 
 echo "::group::Cache"
 if [ -n "${INPUT_CACHE_WRITE}" ]


### PR DESCRIPTION
Remove the "Proof run" group so that the proof results are shown
directly in the log without requiring one more click to expand them.
Since the logs are now only the summary logs, this should not produce
too much output.
