### PR TITLE
fetch-branch: prefer GITHUB_SHA over GITHUB_REF

### DIFF
--- a/scripts/fetch-branch.sh
+++ b/scripts/fetch-branch.sh
@@ -23,11 +23,18 @@ then
     URL="https://${REPO_PATH}"
   fi
 
-  # if an explicit SHA is set as INPUT (e.g. for pull request target), prefer that over GITHUB_REF
+  # if an explicit SHA is set as INPUT (e.g. for pull request target), prefer that
   if [ -n "${INPUT_SHA}" ]
   then
     REF=${INPUT_SHA}
     FETCH=${REF}
+  # if GITHUB_SHA is available, prefer that over REF, because the branch GITHUB_REF
+  # refers to may have been pushed to again to since we have been invoked.
+  elif [ -n "${GITHUB_SHA}" ]
+  then
+    REF=${GITHUB_SHA}
+    FETCH=${REF}
+  # if nothing better is available, use GITHUB_REF
   else
     REF=${GITHUB_REF}
     FETCH=${REF}:${REF}


### PR DESCRIPTION
`GITHUB_REF` is the branch name that triggered the action (e.g. master). `GITHUB_SHA` is the SHA of the commit that triggered the action, but is not always available. If it exists, prefer SHA over REF, because SHA is stable over pushes and changes that might have happened since the action was triggered.

