### PR TITLE
enable MCS tests for more boards

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -18,7 +18,7 @@ architectures: [x86, arm, riscv]
 #     image_platform: name; optional
 #     simulation_binary: string; optional
 #     march: string; optional
-#     req: list of string; optional
+#     req: list of string; optional; names of test boards in machine queue
 #     disabled: optional; (null = false); no hw test on this platform
 #     no_hw_build: optional; (null = false); no hw build for this platform
 

--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -299,18 +299,12 @@ platforms:
     simulation_binary: x86
     march: nehalem
 
+# platforms where MCS is wholly unsupported
+# (for platforms with partial support see sel4test-hw/build.py and comments below)
 mcs_unsupported_platforms:
-# tx1 - scheduler accuracy fails, problem with clk rate in kernel or timestamp
-# at user level?
-# - TX1
-# zynq - scheduler accuracy fails, problem with clk rate in kernel or timestamp
-# at user level?
-- ZYNQ7000
-# not ported yet
-- ODROID_X
-- ZYNQMP
-- IMX8MM_EVK
-- IMX8MQ_EVK
-- MAAXBOARD # To be tested, for now this just copies the setting of IMX8MQ_EVK.
-- ROCKPRO64
-- ODROID_XU4
+  # fails SCHED0012
+  - IMX8MQ_EVK
+  # unsupported for specific configs: ODROID_X4, TX2
+  # unsupported for multicore: SABRE, IMX8MM_EVK
+  # see also https://github.com/seL4/ci-actions/blob/master/sel4test-hw/build.py
+  # function "build_filter" for more MCS exclusions


### PR DESCRIPTION
More boards are supported for MCS than the long list of mcs-unsupported might lead one to believe.

This PR enables more boards, and for some disables specific configurations (e.g. SMP + MCS) that are not supported yet. For these, there are open issues to either enable support or make the configuration impossible to select.

See also seL4/seL4#877 for the discussion on which ones to enable/disable.