### PR TITLE
scripts: new-line unescape manually

### DIFF
--- a/scripts/checkout-manifest.sh
+++ b/scripts/checkout-manifest.sh
@@ -40,7 +40,7 @@ if [ -n "${INPUT_XML}" ]
 then
   echo "Using supplied manifest XML"
   TEST_XML="the-test.xml"
-  echo "${INPUT_XML}" > ".repo/manifests/${TEST_XML}"
+  echo "${INPUT_XML}" | nl-unescape.sh > ".repo/manifests/${TEST_XML}"
   $REPO init ${DEPTH} -m "${TEST_XML}"
 fi
 

--- a/scripts/nl-escape.sh
+++ b/scripts/nl-escape.sh
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-# Escape %, \n, \r for GitHub value setting. It is un-escaped automatically by GH.
+# Escape %, \n, \r for GitHub value setting. Use nl-unescape.sh to undo.
 
 # portable sed is no good for newline replacement, but there is always perl
 perl -pe 's/%/%25/g' | perl -pe 's/\n/%0A/g' | perl -pe 's/\r/%0D/g'

--- a/scripts/nl-unescape.sh
+++ b/scripts/nl-unescape.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Copyright 2022, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Un-Escape %, \n, \r for GitHub value setting.
+
+perl -pe 's/%0D/\r/g' | perl -pe 's/%0A/\n/g' | perl -pe 's/%25/%/g'


### PR DESCRIPTION
%0A, %0D, and %25 were previously un-escaped automatically for GITHUB_OUTPUT settings, but that is no longer the case with the new output file mechanism.

Fixes #231 