### PR TITLE
sel4test-sim: enable MCS simulation tests

### DIFF
--- a/sel4test-sim/build.py
+++ b/sel4test-sim/build.py
@@ -30,9 +30,20 @@ def run_simulation(manifest_dir: str, build: Build):
     return run_build_script(manifest_dir, build, script, junit=True)
 
 
+def build_filter(build: Build) -> bool:
+    plat = build.get_platform()
+
+    # ZYNQ7000 will fail in simulation with 'getCurrentTime() < deadline || globalTimer->isr == 1u'
+    # See discussion: https://github.com/seL4/ci-actions/pull/233#discussion_r3338144123
+    if plat.name == "ZYNQ7000" and build.is_mcs():
+        return False
+
+    return True
+
+
 # If called as main, run all builds from builds.yml
 if __name__ == '__main__':
-    builds = load_builds(os.path.dirname(__file__) + "/builds.yml")
+    builds = load_builds(os.path.dirname(__file__) + "/builds.yml", filter_fun=build_filter)
 
     if len(sys.argv) > 1 and sys.argv[1] == '--dump':
         pprint(builds)

--- a/sel4test-sim/builds.yml
+++ b/sel4test-sim/builds.yml
@@ -19,6 +19,7 @@ default:
 # generating build variants from all platforms, filtered by the build filter
 variants:
     debug: [debug, release]
+    mcs: ['', MCS]
     domains: ['', DOM]
     compiler: [gcc, clang]
     mode: [32, 64]
@@ -36,6 +37,7 @@ variants:
 
 # only generate builds for platforms that have `has_simulation` set
 # only generate builds with DOM set if debug is also set
+# see additional filters in build.py
 build-filter:
     - has_simulation: true
       domains: ''


### PR DESCRIPTION
It appears that switching on MCS for simulation runs "just works".

It'll increase test time for simulation by about a factor of 2, but I think that's worth it and might reduce hardware test load. In particular, it will actually compile MCS variants of all architectures without us having to request a more expensive `hw-build`.