### PR TITLE
add simulation tests for RISCVVIRT32

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -50,6 +50,15 @@ platforms:
     disabled: true
     no_hw_build: true
 
+  RISCVVIRT32:
+    arch: riscv
+    modes: [32]
+    platform: qemu-riscv-virt
+    simulation_binary: qemu-riscv-virt32
+    march: rv32imac
+    disabled: true
+    no_hw_build: true
+
   HIFIVE:
     arch: riscv
     modes: [64]


### PR DESCRIPTION
This is a follow-up on https://github.com/seL4/ci-actions/pull/209 to also add support for the 32-bit version of qemu-riscv-virt. It's currently still in draft state, as building fail for me locally. However, that might not be a blocker to add it to the action already, so it can be used once the issues are fixed.

see also: seL4/seL4#951 