### PR TITLE
platforms: disable quartz64 hardware build

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -73,6 +73,7 @@ platforms:
     platform: quartz64
     march: armv8a
     disabled: true
+    no_hw_build: true
 
   ARMVIRT:
     arch: arm


### PR DESCRIPTION
Currently, the patch set for quartz64 does not compile yet.

See also seL4/seL4#727