### PR TITLE
platforms: enable quartz64 hardware build again

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -82,7 +82,6 @@ platforms:
     platform: quartz64
     march: armv8a
     disabled: true
-    no_hw_build: true
 
   ARMVIRT:
     arch: arm


### PR DESCRIPTION
Revert 6298c0c8 because timer tests are disabled for quartz64 now in sel4test.

 See also PR seL4/sel4test#83 for the change in sel4test