### PR TITLE
webserver: additional build platforms

### DIFF
--- a/webserver/builds.yml
+++ b/webserver/builds.yml
@@ -8,6 +8,15 @@ default:
   success: 'buildroot login:'
 
 builds:
+
 - odroid_xu4:
     platform: ODROID_XU4
-    mode: 32
+
+- qemu-arm-virt:
+    platform: ARMVIRT
+
+- odroid_c2:
+    platform: ODROID_C2
+
+- tx2:
+    platform: TX2


### PR DESCRIPTION
These have not been in CI before, but are listed as supported in the sel4webserver repo.

They will not automatically be built yet, because the build matrix in the sel4webserver repo lists test platforms explicitly, so we can merge here without breaking anything.