### PR TITLE
isabelle-mirror: use old hg for upstream clone

### DIFF
--- a/isabelle-mirror/bin/im-fetch-upstream-hg
+++ b/isabelle-mirror/bin/im-fetch-upstream-hg
@@ -61,7 +61,7 @@ elif [ ! -d "$IM_LOCAL_DIR" ]; then
   mkdir -p "$IM_REPOS_DIR"
   (
     cd "$IM_REPOS_DIR"
-    hg-system clone -U "$IM_REMOTE_URL" "$IM_LOCAL_NAME"
+    hg clone -U "$IM_REMOTE_URL" "$IM_LOCAL_NAME"
   )
 
 else


### PR DESCRIPTION
The local hg version is fixed to a fairly old v3 to preserver git hashes produced by the hg-git version that was used when the Isabelle git clone was first produces.

Using `system-hg` now creates a local clone with features that are too new for that old hg to operate on (in particular feature 'safe-share'). Over the network, old hg is still guaranteed to interoperate correctly with recent servers, so we use that for the clone operation.

Thi should fixe the current mirror failures e.g. [here](https://github.com/seL4/ci-actions/actions/runs/3501666603/jobs/5865506976#step:2:888)