### PR TITLE
platforms: quartz64 still fails sel4bench build

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -82,6 +82,7 @@ platforms:
     platform: quartz64
     march: armv8a
     disabled: true
+    no_hw_build: true
 
   ARMVIRT:
     arch: arm


### PR DESCRIPTION
quartz64 is still not ready for CI, the sel4bench build is failing with missing cmake info:

```
-----------[ start test QUARTZ64_64 ]-----------
  +++ ../init-build.sh -DFASTPATH=TRUE -DHARDWARE=TRUE -DFAULT=TRUE -DAARCH64=TRUE -DPLATFORM=quartz64
  loading initial cache file /github/workspace/projects/sel4bench/settings.cmake
  -- Set platform details from PLATFORM=quartz64
  --   KernelPlatform: quartz64
  -- Setting from flags KernelSel4Arch: aarch64
  -- Found seL4: /github/workspace/kernel
  CMake Error at /github/workspace/kernel/configs/seL4Config.cmake:174 (message):
    Variable 'KernelArch' is not set.
  Call Stack (most recent call first):
    /github/workspace/kernel/FindseL4.cmake:21 (include)
    settings.cmake:34 (sel4_configure_platform_settings)
  -- Configuring incomplete, errors occurred!
  >>> command failed, aborting.
  -----------[ end test QUARTZ64_64 ]-----------
```