### PR TITLE
isabelle-mirror: hg 3.x SSL cannot clone upstream

### DIFF
--- a/isabelle-mirror/bin/im-fetch-upstream-hg
+++ b/isabelle-mirror/bin/im-fetch-upstream-hg
@@ -61,7 +61,13 @@ elif [ ! -d "$IM_LOCAL_DIR" ]; then
   mkdir -p "$IM_REPOS_DIR"
   (
     cd "$IM_REPOS_DIR"
-    hg clone -U "$IM_REMOTE_URL" "$IM_LOCAL_NAME"
+    # We use hg-system here, because the SSL version hg 3.x compiles against does
+    # not work with the upstream Isabelle repository. We need to switch off the
+    # share-safe feature of hg >= 6.2.x in hg-system, because hg 3.x does not
+    # support the share-safe repo requirement. Passing format.use-share-safe=False
+    # should be safe for hg-system with versions < 6.2, because unknown format
+    # options are ignored.
+    hg-system --config format.use-share-safe=False clone -U "$IM_REMOTE_URL" "$IM_LOCAL_NAME"
   )
 
 else


### PR DESCRIPTION
`hg clone` does not work, because the SSL version in hg 3.x is too old for the upstream Isabelle repo.

`hg-system clone` does work, but later leads to failure because it produces a repo format that hg 3.x can no longer interact with.

The change instructs `hg-system` to use an older repo format.

Fixes #242
