### PR TITLE
setup-hw-ssh: use dedicated CI account

### DIFF
--- a/scripts/setup-hw-ssh.sh
+++ b/scripts/setup-hw-ssh.sh
@@ -19,10 +19,10 @@ echo "ControlPersist 15" >> ~/.ssh/config
 echo >> ~/.ssh/config
 echo "Host ts" >> ~/.ssh/config
 echo "Hostname login.trustworthy.systems" >> ~/.ssh/config
-echo "User kleing" >> ~/.ssh/config
+echo "User sel4_ci" >> ~/.ssh/config
 echo >> ~/.ssh/config
 echo "Host tftp.keg.cse.unsw.edu.au" >> ~/.ssh/config
-echo "User kleing" >> ~/.ssh/config
+echo "User sel4_ci" >> ~/.ssh/config
 echo "ProxyJump ts" >> ~/.ssh/config
 echo >> ~/.ssh/config
 


### PR DESCRIPTION
Hardware tests used to run under my personal account which has too much access.