### PR TITLE
enable CI tests for NUM_DOMAINS > 1

### DIFF
--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -178,13 +178,24 @@ class Build:
     def can_smp(self) -> bool:
         return self.get_mode() in self.get_platform().smp
 
-    def set_smp(self) -> bool:
+    def set_smp(self):
         if not self.can_smp():
             raise ValidationException("not Build.can_smp()")
         self.settings['SMP'] = "TRUE"
 
     def is_smp(self) -> bool:
         return self.settings.get('SMP') != None
+
+    def can_domains(self) -> bool:
+        return not self.is_smp()
+
+    def set_domains(self):
+        if not self.can_domains():
+            raise ValidationException("not Build.can_domains()")
+        self.settings['DOMAINS'] = "TRUE"
+
+    def is_domains(self) -> bool:
+        return self.settings.get('DOMAINS') != None
 
     def validate(self):
         if not self.get_mode():
@@ -201,6 +212,8 @@ class Build:
             raise ValidationException("not Build.can_release()")
         if self.is_hyp() and not self.can_hyp():
             raise ValidationException("not Build.can_hyp()")
+        if self.is_domains() and not self.can_domains():
+            raise ValidationException("not Build.can_domains()")
 
     def __repr__(self) -> str:
         return \
@@ -731,6 +744,8 @@ def build_for_variant(base_build: Build, variant, filter_fun=lambda x: True) -> 
                 build.set_smp()
             elif feature == 'hyp' and val != '':
                 build.set_hyp()
+            elif feature == 'domains' and val != '':
+                build.set_domains()
             elif feature == 'debug' and val == 'release':
                 build.set_release()
             elif feature == 'debug' and val == 'verification':
@@ -812,6 +827,9 @@ def filtered(build: Build, build_filters: dict) -> Optional[Build]:
                     return False
             elif k == 'hyp':
                 if v != '' and not build.is_hyp():
+                    return False
+            elif k == 'domains':
+                if v != '' and not build.is_domains():
                     return False
             elif k == 'req':
                 for req in v:

--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -820,16 +820,16 @@ def filtered(build: Build, build_filters: dict) -> Optional[Build]:
                 if build.get_mode() not in v:
                     return False
             elif k == 'mcs':
-                if v != '' and not build.is_mcs():
+                if (v == '') == build.is_mcs():
                     return False
             elif k == 'smp':
-                if v != '' and not build.is_smp():
+                if (v == '') == build.is_smp():
                     return False
             elif k == 'hyp':
-                if v != '' and not build.is_hyp():
+                if (v == '') == build.is_hyp():
                     return False
             elif k == 'domains':
-                if v != '' and not build.is_domains():
+                if (v == '') == build.is_domains():
                     return False
             elif k == 'req':
                 for req in v:

--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -108,7 +108,7 @@ class Build:
         self.settings["VERIFICATION"] = "TRUE"
 
     def is_verification(self) -> bool:
-        return self.settings.get("VERIFICATION") != None
+        return self.settings.get("VERIFICATION") is not None
 
     def can_release(self):
         # Bamboo excludes RELEASE for RPI3:
@@ -120,7 +120,7 @@ class Build:
         self.settings["RELEASE"] = "TRUE"
 
     def is_release(self) -> bool:
-        return self.settings.get("RELEASE") != None
+        return self.settings.get("RELEASE") is not None
 
     def is_debug(self) -> bool:
         return not self.is_release() and not self.is_verification()
@@ -144,7 +144,8 @@ class Build:
             raise ValidationException
 
     def is_hyp(self) -> bool:
-        return self.settings.get("ARM_HYP") != None or self.settings.get("KernelVTX") != None
+        return self.settings.get("ARM_HYP") is not None or \
+            self.settings.get("KernelVTX") is not None
 
     def can_clang(self) -> bool:
         # clang 8 does not support riscv, and Bamboo has no clang for TX1 64:
@@ -159,7 +160,7 @@ class Build:
         self.settings["TRIPLE"] = self.get_platform().get_triple(self.get_mode())
 
     def is_clang(self) -> bool:
-        return self.settings.get("TRIPLE") != None
+        return self.settings.get("TRIPLE") is not None
 
     def is_gcc(self) -> bool:
         return not self.is_clang()
@@ -173,7 +174,7 @@ class Build:
         self.settings['MCS'] = "TRUE"
 
     def is_mcs(self) -> bool:
-        return self.settings.get('MCS') != None
+        return self.settings.get('MCS') is not None
 
     def can_smp(self) -> bool:
         return self.get_mode() in self.get_platform().smp
@@ -184,7 +185,7 @@ class Build:
         self.settings['SMP'] = "TRUE"
 
     def is_smp(self) -> bool:
-        return self.settings.get('SMP') != None
+        return self.settings.get('SMP') is not None
 
     def can_domains(self) -> bool:
         return not self.is_smp()
@@ -195,7 +196,7 @@ class Build:
         self.settings['DOMAINS'] = "TRUE"
 
     def is_domains(self) -> bool:
-        return self.settings.get('DOMAINS') != None
+        return self.settings.get('DOMAINS') is not None
 
     def validate(self):
         if not self.get_mode():

--- a/sel4test-hw/build.py
+++ b/sel4test-hw/build.py
@@ -77,6 +77,10 @@ def build_filter(build: Build) -> bool:
         if build.is_hyp() and (build.is_smp() or build.is_verification()):
             return False
 
+    # run NUM_DOMAINS > 1 tests only on release builds
+    if build.is_domains() and not build.is_release():
+        return False
+
     return True
 
 

--- a/sel4test-hw/builds.yml
+++ b/sel4test-hw/builds.yml
@@ -14,5 +14,6 @@ variants:
     smp: ['', SMP]
     hyp: ['', hyp]
     mcs: ['', MCS]
+    domains: ['', DOM]
     compiler: [gcc, clang]
     mode: [32, 64]

--- a/sel4test-sim/builds.yml
+++ b/sel4test-sim/builds.yml
@@ -19,6 +19,7 @@ default:
 # generating build variants from all platforms, filtered by the build filter
 variants:
     debug: [debug, release]
+    domains: ['', DOM]
     compiler: [gcc, clang]
     mode: [32, 64]
 
@@ -28,13 +29,20 @@ variants:
 #     smp: ['', SMP]
 #     hyp: ['', hyp]
 #     mcs: ['', MCS]
+#     domains: ['', DOM]
 #     compiler: [gcc, clang]
 #     mode: [32, 64]
 
 
 # only generate builds for platofrms that have `simulation_binary` set
+# only generate builds with DOM set if debug is also set
 build-filter:
     - simulation_binary: true
+      domains: ''
+      arch: [arm, x86]
+    - simulation_binary: true
+      domains: DOM
+      debug: [debug]
       arch: [arm, x86]
     - simulation_binary: true
       arch: [riscv]


### PR DESCRIPTION
As @robs-cse found out, the domain scheduler is entirely untested in CI. This PR rectifies that by:

- adding a `domains` variant dimension to the build matrix
- enabling domain tests for sel4test-sim
- enabling domain tests for sel4test-hw

The combination of domains and SMP is disabled globally, all other combinations are possible.

To not increase the overall number of tests too much, we enabled domain tests in simulation for debug builds (because release is not available for riscv), and for release builds in hardware tests.

Only sel4test-sim and sel4test-hw are currently affected, no other builds.