### PR TITLE
builds: increase default timeout

### DIFF
--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -59,7 +59,7 @@ class Build:
         self.success = None
         self.error = None
         self.settings = {}
-        self.timeout = 600
+        self.timeout = 900
         self.disabled = False
         self.image_base_name = "sel4test-driver"
         [self.name] = entries.keys()


### PR DESCRIPTION
Some of the sel4bench tests seem to be sometimes hitting the timeout and usually hanging tests on the default timeout are rare, so it should be safe to increase.
