### PR TITLE
temporarily disable domain tests for hardware runs

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -217,7 +217,6 @@ platforms:
     platform: zynqmp
     req: [zcu106]
     march: armv8a
-    disabled: true
 
   HIKEY:
     arch: arm

--- a/sel4test-hw/builds.yml
+++ b/sel4test-hw/builds.yml
@@ -14,6 +14,6 @@ variants:
     smp: ['', SMP]
     hyp: ['', hyp]
     mcs: ['', MCS]
-    domains: ['', DOM]
+    # domains: ['', DOM]
     compiler: [gcc, clang]
     mode: [32, 64]


### PR DESCRIPTION
The simulation tests work fine for domains, but the hardware runs fail too many of the scheduling tests. Probably because the domain schedule interferes too much with timing. Needs more investigation.

Unrelated small change: re-add zcu106, which should now work again.