### PR TITLE
platforms: enable Odroid-C4

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -152,10 +152,8 @@ platforms:
     arch: arm
     modes: [64]
     platform: odroidc4
-    req: [odroidc4]
+    req: [odroidc4_1]
     march: armv8a
-    disabled: true
-    no_hw_build: true
 
   ODROID_X:
     arch: arm

--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -151,6 +151,8 @@ platforms:
   ODROID_C4:
     arch: arm
     modes: [64]
+    aarch_hyp: [64]
+    smp: [64]
     platform: odroidc4
     req: [odroidc4_1]
     march: armv8a


### PR DESCRIPTION
The Odroid-C4 has been added to MQ and passes seL4test in default/MCS configurations. Most likely passes more but am yet to test other configurations.