### PR TITLE
sel4test-hw: exclude mcs_hyp_smp for odroid_c4

### DIFF
--- a/sel4test-hw/build.py
+++ b/sel4test-hw/build.py
@@ -60,9 +60,9 @@ def build_filter(build: Build) -> bool:
         # No MCS + SMP for platforms with global timer for now (see seL4/seL4#513)
         if plat.name == 'SABRE' and build.is_smp() and build.is_mcs():
             return False
-        # SCHED_CONTEXT_0014 fails on TX2: https://github.com/seL4/seL4/issues/928
-        if plat.name == 'TX2' and build.is_mcs() and build.is_smp() and \
-           build.is_hyp() and build.is_clang():
+        # SCHED_CONTEXT_0014 fails on TX2 and ODROID_C4: https://github.com/seL4/seL4/issues/928
+        if (plat.name == 'TX2' or plat.name == 'ODROID_C4') and \
+           build.is_mcs() and build.is_smp() and build.is_hyp() and build.is_clang():
             return False
         # CACHEFLUSH0001 fails on ODROID_XU4: https://github.com/seL4/sel4test/issues/80
         if plat.name == 'ODROID_XU4' and build.is_debug() and build.is_mcs() and \


### PR DESCRIPTION
Same symptom as for TX2, see also seL4/seL4#928