### PR TITLE
aws-proofs: update repo on start-up

### DIFF
--- a/aws-proofs/vm-steps.sh
+++ b/aws-proofs/vm-steps.sh
@@ -10,6 +10,8 @@
 set -e
 
 echo "::group::Setting up"
+curl https://storage.googleapis.com/git-repo-downloads/repo > ~/.local/bin
+chmod 755 ~/.local/bin/repo
 export PATH=/home/test-runner/ci-actions/scripts:/home/test-runner/.local/bin:/home/test-runner/.bin:$PATH
 mkdir ver
 cd ver


### PR DESCRIPTION
Update the repo tool when the job starts up.

The repo tool wants to update itself more frequently than the VM images and produces annoying chatter when it is not on the latest version.