### PR TITLE
Fix YAML parsing when `mcs_unsupported_platforms` is empty

### DIFF
--- a/seL4-platforms/platforms.py
+++ b/seL4-platforms/platforms.py
@@ -218,6 +218,9 @@ platforms = {name: Platform(name, plat)
              for (name, plat) in _yaml_platforms["platforms"].items()}
 
 mcs_unsupported = _yaml_platforms["mcs_unsupported_platforms"]
+# If there are no unsupported MCS platforms, this will be None
+mcs_unsupported = mcs_unsupported if mcs_unsupported is not None else []
+
 for p in mcs_unsupported:
     if not platforms.get(p):
         print(f"Warning: unknown platform '{p}' in mcs_unsupported list")

--- a/seL4-platforms/platforms.py
+++ b/seL4-platforms/platforms.py
@@ -23,7 +23,7 @@ import os
 # exported names:
 __all__ = [
     "Platform", "ValidationException", "load_yaml", "gh_output",
-    "all_architectures", "all_modes", "platforms", "unsupported"
+    "all_architectures", "all_modes", "platforms", "mcs_unsupported"
 ]
 
 
@@ -69,7 +69,7 @@ class Platform:
             if not isinstance(sub, list):
                 return False
             for x in sub:
-                if not x in container:
+                if x not in container:
                     return False
             return True
 
@@ -77,7 +77,7 @@ class Platform:
             return sublist(modes, all_modes)
 
         def opt_str(name):
-            return name == None or isinstance(name, str)
+            return name is None or isinstance(name, str)
 
         return isinstance(self.name, str) and \
             self.arch in all_architectures and \
@@ -87,7 +87,7 @@ class Platform:
             opt_str(self.image_platform) and \
             opt_str(self.simulation_binary) and \
             opt_str(self.march) and \
-            (self.req == None or isinstance(self.req, str) or isinstance(self.req, list)) and \
+            (self.req is None or isinstance(self.req, str) or isinstance(self.req, list)) and \
             isinstance(self.disabled, bool) and \
             isinstance(self.no_hw_build, bool)
 


### PR DESCRIPTION
This checks whether the `mcs_unsupported_platforms` list in `seL4-platforms/platforms.yml` is empty before trying to iterate over it to avoid errors observed in the following output https://github.com/seL4/seL4/actions/runs/4443812105/jobs/7801440632. I unfortunately did not catch this before approving https://github.com/seL4/ci-actions/pull/263.