### PR TITLE
python: upgrade default python version for GitHub

### DIFF
--- a/scripts/install-python.sh
+++ b/scripts/install-python.sh
@@ -4,11 +4,11 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-# Installs python 3.8; assumes GitHub's ubuntu-latest
+# Installs python 3.10; assumes GitHub's ubuntu-latest
 
-echo "Installing python 3.8"
-sudo apt-get install -qq python3.8 > /dev/null
-sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
-sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
+echo "Installing python 3.10"
+sudo apt-get install -qq python3.10 > /dev/null
+sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1
+sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
 python3 --version
 pip3 install -q --upgrade pip setuptools launchpadlib wheel


### PR DESCRIPTION
GitHub runners now have python 3.10 available by default (Ubuntu 22.04)