### PR TITLE
aws-proofs: scale timeouts by 50% for cloud

### DIFF
--- a/aws-proofs/vm-steps.sh
+++ b/aws-proofs/vm-steps.sh
@@ -86,7 +86,10 @@ export SKIP_DUPLICATED_PROOFS=${INPUT_SKIP_DUPS}
 FAIL=0
 
 L4V_DIR="$PWD/l4v"
-do_run_tests() { (cd "$L4V_DIR" && ./run_tests -j 2 ${INPUT_SESSION} "$@"); }
+do_run_tests() {
+  # 2 parallel jobs, scale timeouts by 50%
+  (cd "$L4V_DIR" && ./run_tests --scale-timeouts 1.5 -j 2 ${INPUT_SESSION} "$@");
+}
 
 do_run_tests || FAIL=1
 

--- a/bashisms/README.md
+++ b/bashisms/README.md
@@ -39,6 +39,6 @@ jobs:
 ### Maintenance
 
 The `checkbashism` script in `../scripts` is directly extracted from
-<https://deb.debian.org/debian/pool/main/d/devscripts/devscripts_2.23.2.tar.xz>.
+<https://deb.debian.org/debian/pool/main/d/devscripts/devscripts_2.23.3.tar.xz>.
 Installing it via `apt-get` takes forever, because the rest of the devscripts
 has lots of dependencies.


### PR DESCRIPTION
Scale timeouts by 50% to provide an extra stretch factor for cloud tests.

AWS runners don't seem to be reliable in load, specifically the X64 CRefine session is sometimes timing out even though on a normal run there'd be over 1h left. Scaling the timeout should avoid these.