### PR TITLE
platforms: enable Raspberry Pi 4B

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -251,7 +251,6 @@ platforms:
     req: [pi4B]
     image_platform: bcm2711
     march: armv8a
-    disabled: true
 
   TX1:
     arch: arm

--- a/sel4test-hw/build.py
+++ b/sel4test-hw/build.py
@@ -23,8 +23,14 @@ import sys
 def hw_build(manifest_dir: str, build: Build):
     """Run one hardware build."""
 
+    settings = build.settings_args()
+    if build.name == "RPI4":
+        # The Raspberry Pi 4B model that is used for hardware testing has 4GB
+        # of RAM, which we must specify when building the kernel.
+        settings += " -DRPI4_MEMORY=4096"
+
     script = [
-        ["../init-build.sh"] + build.settings_args(),
+        ["../init-build.sh"] + settings,
         ["ninja"],
         ["tar", "czf", f"../{build.name}-images.tar.gz", "images/"]
     ]


### PR DESCRIPTION
RPi4B now works in machine queue again, hold off on merging since the device tree in seL4 needs a patch to get sel4test to wrok.