### PR TITLE
bashims: bump devscripts version

### DIFF
--- a/bashisms/README.md
+++ b/bashisms/README.md
@@ -39,6 +39,6 @@ jobs:
 ### Maintenance
 
 The `checkbashism` script in `../scripts` is directly extracted from
-<https://deb.debian.org/debian/pool/main/d/devscripts/devscripts_2.23.3.tar.xz>.
+<https://deb.debian.org/debian/pool/main/d/devscripts/devscripts_2.23.6.tar.xz>.
 Installing it via `apt-get` takes forever, because the rest of the devscripts
 has lots of dependencies.


### PR DESCRIPTION
Make the link checker happy again

There are no changes:  https://salsa.debian.org/debian/devscripts/-/commits/master/scripts/checkbashisms.pl