### PR TITLE
platforms: add tqma8xqp1gb to hw test

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -132,8 +132,8 @@ platforms:
     modes: [64]
     smp: [64]
     platform: tqma8xqp1gb
+    req: [tqma]
     march: armv8a
-    disabled: true
 
   OMAP3:
     arch: arm


### PR DESCRIPTION
The corresponding tqma board is now available in the machine queue.