### PR TITLE
sel4test-hw: prepare kernel.elf build artifact

### DIFF
--- a/sel4test-hw/build.py
+++ b/sel4test-hw/build.py
@@ -31,7 +31,8 @@ def hw_build(manifest_dir: str, build: Build):
     script = [
         ["../init-build.sh"] + build.settings_args(),
         ["ninja"],
-        ["tar", "czf", f"../{build.name}-images.tar.gz", "images/"]
+        ["tar", "czf", f"../{build.name}-images.tar.gz", "images/"],
+        ["cp", "kernel/kernel.elf", f"../{build.name}-kernel.elf"]
     ]
 
     return run_build_script(manifest_dir, build, script)


### PR DESCRIPTION
Leave kernel.elf under a predictable name for each build variant in a place where GitHub artifact upload can later find it.

This will need a change in the workflow for sel4test in the seL4 repo to then actually upload the produced artifact.