### PR TITLE
use ARM_MCS_verified.cmake for MCS build

### DIFF
--- a/standalone-kernel/compile_kernel.sh
+++ b/standalone-kernel/compile_kernel.sh
@@ -21,11 +21,16 @@ case "${INPUT_ARCH}" in
         gcc_cfg="AARCH64"
         llvm_triple="aarch64-linux-gnu"
         ;;
+    RISCV32)
+        gcc_cfg="RISCV32"
+        # the 64-bit toolchain can build for 32-bit also.
+        llvm_triple="riscv64-unknown-elf"
+        ;;
     RISCV64)
         gcc_cfg="RISCV64"
         llvm_triple="riscv64-unknown-elf"
         ;;
-    X64)
+    IA32|X64)
         # just use the standard host compiler
         ;;
     *)

--- a/standalone-kernel/compile_kernel.sh
+++ b/standalone-kernel/compile_kernel.sh
@@ -8,84 +8,99 @@
 echo "Arch: $INPUT_ARCH"
 echo "Comp: $INPUT_COMPILER"
 
-set -e
+set -eu
 
-extra_config=""
-
-case $INPUT_ARCH in
-    ARM*)
-        case $INPUT_COMPILER in
-            gcc)
-                extra_config="${extra_config} -DAARCH32=TRUE"
-                ;;
-            llvm)
-                extra_config="${extra_config} -DTRIPLE=arm-linux-gnueabi"
-                ;;
-            *)
-                echo "Unknown input compiler"
-                exit 1
-        esac
+gcc_cfg=""
+llvm_triple=""
+case "${INPUT_ARCH}" in
+    ARM|ARM_HYP)
+        gcc_cfg="AARCH32"
+        llvm_triple="arm-linux-gnueabi"
         ;;
     AARCH64)
-        case $INPUT_COMPILER in
-            gcc)
-                extra_config="${extra_config} -DAARCH64=TRUE"
-                ;;
-            llvm)
-                extra_config="${extra_config} -DTRIPLE=aarch64-linux-gnu"
-                ;;
-            *)
-                echo "Unknown input compiler"
-                exit 1
-        esac
+        gcc_cfg="AARCH64"
+        llvm_triple="aarch64-linux-gnu"
         ;;
     RISCV64)
-        case $INPUT_COMPILER in
-            gcc)
-                extra_config="${extra_config} -DRISCV64=TRUE"
-                ;;
-            llvm)
-                extra_config="${extra_config} -DTRIPLE=riscv64-unknown-elf"
-                ;;
-            *)
-                echo "Unknown input compiler"
-                exit 1
-        esac
+        gcc_cfg="RISCV64"
+        llvm_triple="riscv64-unknown-elf"
         ;;
     X64)
-        # no config needed
+        # just use the standard host compiler
         ;;
     *)
-        echo "Unknown ARCH"
+        echo "Unknown ARCH '${INPUT_ARCH}'"
         exit 1
+        ;;
 esac
 
-echo "::group::Run CMake"
-mkdir build
-cd build
-set -x
-cmake -DCMAKE_TOOLCHAIN_FILE="$INPUT_COMPILER".cmake -G Ninja -C ../configs/"$INPUT_ARCH"_verified.cmake $extra_config ../
-set +x
-echo "::endgroup::"
+toolchain_flags=""
+case "${INPUT_COMPILER}" in
+    gcc)
+        if [ ! -z "${gcc_cfg}" ]; then
+            toolchain_flags="-D${gcc_cfg}=TRUE"
+        fi
+        ;;
+    llvm)
+        if [ ! -z "${llvm_triple}" ]; then
+            toolchain_flags="-DTRIPLE=${llvm_triple}"
+        fi
+        ;;
+    *)
+        echo "Unknown COMPILER '${INPUT_COMPILER}'"
+        exit 1
+        ;;
+esac
+toolchain_flags="-DCMAKE_TOOLCHAIN_FILE=${INPUT_COMPILER}.cmake ${toolchain_flags}"
 
-echo "::group::Run Ninja"
-set -x
-ninja kernel.elf
-set +x
-echo "::endgroup::"
+do_compile_kernel()
+{
+    variant=${1:-}
 
-echo "::group::Run CMake (MCS)"
-cd ..
-rm -rf build
-mkdir build
-cd build
-set -x
-cmake -DCMAKE_TOOLCHAIN_FILE="$INPUT_COMPILER".cmake -G Ninja -C ../configs/"$INPUT_ARCH"_verified.cmake $extra_config -DKernelIsMCS=TRUE ../
-set +x
-echo "::endgroup::"
+    build_folder="build"
+    config_file="configs/${INPUT_ARCH}_verified.cmake"
+    variant_info=""
+    extra_params=""
 
-echo "::group::Run Ninja (MCS)"
-set -x
-ninja kernel.elf
-set +x
-echo "::endgroup::"
+    if [ ! -z "${variant}" ]; then
+        case "${variant}" in
+            MCS)
+                build_folder="${build_folder}-${variant}"
+                variant_info=" (${variant})"
+                extra_params="${extra_params} -DKernelIsMCS=TRUE"
+                ;;
+            *)
+                echo "Unknown variant '${variant}'"
+                exit 1
+                ;;
+        esac
+    fi
+
+    # Unfortunately, CMake does not halt with a nice and clear error if the
+    # config file does not exist. Instead, it logs an error that it could not
+    # process the file and continues as if the file was empty. This causes some
+    # rather odd errors then, so it's better to fail here with a clear message.
+    if [ ! -f "${config_file}" ]; then
+        echo "missing config file '${config_file}'"
+        exit 1
+    fi
+
+    echo "::group::Run CMake${variant_info}"
+    ( # run in sub shell
+        set -x
+        cmake -G Ninja -B ${build_folder} -C ${config_file} ${toolchain_flags} ${extra_params}
+    )
+    echo "::endgroup::"
+
+    echo "::group::Run Ninja${variant_info}"
+    ( # run in sub shell
+        set -x
+        ninja -C ${build_folder} kernel.elf
+    )
+    echo "::endgroup::"
+}
+
+# build standard kernel
+do_compile_kernel
+# build MCS kernel
+do_compile_kernel "MCS"

--- a/standalone-kernel/compile_kernel.sh
+++ b/standalone-kernel/compile_kernel.sh
@@ -72,7 +72,14 @@ do_compile_kernel()
             MCS)
                 build_folder="${build_folder}-${variant}"
                 variant_info=" (${variant})"
-                extra_params="${extra_params} -DKernelIsMCS=TRUE"
+                # Use a dedicated config file if available, otherwise just use
+                # the default config and enable MCS.
+                try_config_file="configs/${INPUT_ARCH}_MCS_verified.cmake"
+                if [ -f "${try_config_file}" ]; then
+                    config_file=${try_config_file}
+                else
+                    extra_params="${extra_params} -DKernelIsMCS=TRUE"
+                fi
                 ;;
             *)
                 echo "Unknown variant '${variant}'"


### PR DESCRIPTION
- make script more generic
  - remove redundancy
  - check if config file exists
  - remove unnecessary CMake parameters
  - use separate build folder for non-MCS and MCS
  - improve comments
- support RISCV32 and IA32
- use `xxx_MCS_verified.cmake` for MCS builds if is exists (RISCV64, ARM), see https://github.com/seL4/ci-actions/issues/294

A test run can be found at https://github.com/axel-h/seL4/pull/131 (with some dummy config for RISCV32/IA32)