### PR TITLE
fix typo for RISC-V 32-bit

### DIFF
--- a/seL4-platforms/platforms.py
+++ b/seL4-platforms/platforms.py
@@ -187,7 +187,7 @@ class Platform:
             return {32: "IA32", 64: "x86_64"}[mode]
 
         if self.arch == "riscv":
-            return {32: "RC32IMAC", 64: "RV64IMAC"}[mode]
+            return {32: "RV32IMAC", 64: "RV64IMAC"}[mode]
 
         return self.march.capitalize()
 


### PR DESCRIPTION
I think this had no impact for far, because it's used for some status page only and we don't have RV32 hardware yet.