### PR TITLE
clang is supported everywhere now

### DIFF
--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -147,16 +147,7 @@ class Build:
         return self.settings.get("ARM_HYP") is not None or \
             self.settings.get("KernelVTX") is not None
 
-    def can_clang(self) -> bool:
-        # clang 8 does not support riscv, and Bamboo has no clang for TX1 64:
-        return not (
-            self.get_platform().arch == 'riscv' or
-            self.get_platform().name == 'TX1' and self.get_mode() == 64
-        )
-
     def set_clang(self):
-        if not self.can_clang():
-            raise ValidationException("not Build.can_clang()")
         self.settings["TRIPLE"] = self.get_platform().get_triple(self.get_mode())
 
     def is_clang(self) -> bool:
@@ -203,8 +194,6 @@ class Build:
             raise ValidationException("Build: no unique mode")
         if not self.get_platform():
             raise ValidationException("Build: no platform")
-        if self.is_clang() and not self.can_clang():
-            raise ValidationException("not Build.can_clang()")
         if self.is_mcs() and not self.can_mcs():
             raise ValidationException("not Build.can_mcs()")
         if self.is_smp() and not self.can_smp():

--- a/seL4-platforms/platforms.py
+++ b/seL4-platforms/platforms.py
@@ -167,8 +167,8 @@ class Platform:
                           64: "x86_64-linux-gnu"},
                 "arm":   {32: "arm-linux-gnueabi",
                           64: "aarch64-linux-gnu"},
-                "riscv": {32: "riscv32-linux-gnu",
-                          64: "riscv64-linux-gnu"}}[self.arch][mode]
+                "riscv": {32: "riscv64-unknown-elf",
+                          64: "riscv64-unknown-elf"}}[self.arch][mode]
 
     def image_names(self, mode: int, root_task: str) -> list:
         """Return generated image name"""


### PR DESCRIPTION
This is following up on the comment https://github.com/seL4/ci-actions/pull/297#issuecomment-1881904182, we can use clang everywhere as the builds seem to work fine. So remove the blockers here, they should be put into specific workflow the in case there are still issues.

Test run is here: https://github.com/axel-h/seL4/actions/runs/7464262889/job/20310849733?pr=137 (added dummy for RV32;  removed some HW platforms so the build does not take ages)