### PR TITLE
sel4test-hw: remove mcs+hyp+smp+clang for TX1

### DIFF
--- a/sel4test-hw/build.py
+++ b/sel4test-hw/build.py
@@ -66,8 +66,8 @@ def build_filter(build: Build) -> bool:
         # No MCS + SMP for platforms with global timer for now (see seL4/seL4#513)
         if plat.name == 'SABRE' and build.is_smp() and build.is_mcs():
             return False
-        # SCHED_CONTEXT_0014 fails on TX2 and ODROID_C4: https://github.com/seL4/seL4/issues/928
-        if (plat.name == 'TX2' or plat.name == 'ODROID_C4') and \
+        # SCHED_CONTEXT_0014 fails on TX1, TX2 and ODROID_C4: https://github.com/seL4/seL4/issues/928
+        if plat.name in ['TX1', 'TX2', 'ODROID_C4'] and \
            build.is_mcs() and build.is_smp() and build.is_hyp() and build.is_clang():
             return False
         # CACHEFLUSH0001 fails on ODROID_XU4: https://github.com/seL4/sel4test/issues/80


### PR DESCRIPTION
See also seL4/seL4#928 -- TX1 has the same issue as TX2 and ODROID_C4