### PR TITLE
platforms: add MaaXBoard

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -116,8 +116,8 @@ platforms:
     smp: [64]
     aarch_hyp: [64]
     platform: maaxboard
+    req: [maaxboard1]
     march: armv8a
-    disabled: true
 
   IMX8MM_EVK:
     arch: arm


### PR DESCRIPTION
The MaaXBoard is the same SoC as the i.MX8MQ and so all the test configurations that work for the i.MX8MQ-EVK should also work.

Draft because the board is currently having network issues but should be resolved in a couple of days when we get a new network switch.