### PR TITLE
platforms: temporarily remove imx8mm from CI

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -126,6 +126,7 @@ platforms:
     platform: imx8mm-evk
     req: [imx8mm]
     march: armv8a
+    disabled: true # temporarily disabled for CI for benchmarking
 
   TQMA8XQP1GB:
     arch: arm


### PR DESCRIPTION
Should be put back in after 25 Jan 2024 at the latest.