### PR TITLE
platforms: disable MCS for Maaxboard for now

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -329,8 +329,9 @@ platforms:
 # platforms where MCS is wholly unsupported
 # (for platforms with partial support see sel4test-hw/build.py and comments below)
 mcs_unsupported_platforms:
-  # fails SCHED0012 and debug assertions on boot:
+  # both fail SCHED0012 and debug assertions on boot:
   - IMX8MQ_EVK
+  - MAAXBOARD
   # unsupported for specific configs: ODROID_X4, TX2
   # unsupported for multicore: SABRE, IMX8MM_EVK
   # see also https://github.com/seL4/ci-actions/blob/master/sel4test-hw/build.py


### PR DESCRIPTION
Shows same (or worse) behaviour as IMX8MQ_EVK