### PR TITLE
camkes-vm: add vm_minimal_zcu102 run

### DIFF
--- a/camkes-vm/build.py
+++ b/camkes-vm/build.py
@@ -33,6 +33,10 @@ def run_build(manifest_dir: str, build: Build):
     if plat.arch == 'x86':
         del build.settings['PLATFORM']  # not used for x86 in this test, avoid warning
 
+    # if vm_platform is set, the init-build.sh script expects a different platform name.
+    if build.vm_platform:
+        build.settings['PLATFORM'] = build.vm_platform
+
     script = [
         ["../init-build.sh"] + build.settings_args(),
         ["ninja"],

--- a/camkes-vm/builds.yml
+++ b/camkes-vm/builds.yml
@@ -33,7 +33,7 @@ builds:
     platform: TK1
 - odroid_vm:
     platform: ODROID_XU
-    succes: 'root@NICTAcopter:'
+    success: 'root@NICTAcopter:'
 - vm_minimal_tx1:
     app: vm_minimal
     platform: TX1
@@ -62,21 +62,21 @@ builds:
 - vm_virtio_net_arping_xu4:
     app: vm_virtio_net
     platform: ODROID_XU4
-    succes: 'arping test was successful'
+    success: 'arping test was successful'
 - vm_virtio_net_ping_xu4:
     app: vm_virtio_net
     platform: ODROID_XU4
-    succes: 'Ping test was successful'
+    success: 'Ping test was successful'
     setttings:
         VIRTIO_NET_PING: '1'
 - vm_virtio_net_arping_tx2:
     app: vm_virtio_net
     platform: TX2
-    succes: 'arping test was successful'
+    success: 'arping test was successful'
 - vm_virtio_net_ping_tx2:
     app: vm_virtio_net
     platform: TX2
-    succes: 'Ping test was successful'
+    success: 'Ping test was successful'
     setttings:
         VIRTIO_NET_PING: '1'
 - vm_multi:
@@ -84,4 +84,4 @@ builds:
     success: 'buildroot login:.*buildroot login:.*buildroot login:'
 - vm_cross_connector:
     platform: ODROID_XU4
-    succes: 'Finished crossvm test script'
+    success: 'Finished crossvm test script'

--- a/camkes-vm/builds.yml
+++ b/camkes-vm/builds.yml
@@ -9,6 +9,8 @@ default:
   error: 'Halting...'
   debug: release
   platform: PC99
+  # use if -DPLATFORM for init script is different from PLATFORM name:
+  vm_platform:
 
 builds:
 # PC99:
@@ -40,6 +42,11 @@ builds:
 - vm_minimal_tx2:
     app: vm_minimal
     platform: TX2
+- vm_minimal_zcu102:
+    app: vm_minimal
+    platform: ZYNQMP
+    vm_platform: zcu102
+    success: "@xilinx-zcu102"
 - vm_minimal_sim:
     app: vm_minimal
     platform: ARMVIRT


### PR DESCRIPTION
- fix typo in `success` key string in CAmkES VM runs (was `succes`)
- add mechanism to override platform name for VM builds (because `zynqmp` needs `zcu102` in `-DPLATFORM=..`)
- add `vm_minimal_zcu102`


(replaces #313)