### PR TITLE
camkes-vm: fix typo in settings key string

### DIFF
--- a/camkes-vm/builds.yml
+++ b/camkes-vm/builds.yml
@@ -57,12 +57,12 @@ builds:
 - vm_minimal_smp_tx1:
     app: vm_minimal
     platform: TX1
-    setttings:
+    settings:
         NUM_NODES: 4
 - vm_minimal_smp_tx2:
     app: vm_minimal
     platform: TX2
-    setttings:
+    settings:
         NUM_NODES: 4
 - vm_serial_server:
     platform: ODROID_XU4
@@ -74,7 +74,7 @@ builds:
     app: vm_virtio_net
     platform: ODROID_XU4
     success: 'Ping test was successful'
-    setttings:
+    settings:
         VIRTIO_NET_PING: '1'
 - vm_virtio_net_arping_tx2:
     app: vm_virtio_net
@@ -84,7 +84,7 @@ builds:
     app: vm_virtio_net
     platform: TX2
     success: 'Ping test was successful'
-    setttings:
+    settings:
         VIRTIO_NET_PING: '1'
 - vm_multi:
     platform: ODROID_XU4


### PR DESCRIPTION
This fixes another typo, which seems to be the reasons some CAmkES VM hardware test fail - they just don't run what they are supposed to run. We have a successful test now: https://github.com/seL4/camkes-vm-examples/actions/runs/7671627886/job/20910564830?pr=59