### PR TITLE
camkes-vm: add vm_minimal for ODROID_C2

### DIFF
--- a/camkes-vm/builds.yml
+++ b/camkes-vm/builds.yml
@@ -65,6 +65,9 @@ builds:
     platform: TX2
     settings:
         NUM_NODES: 4
+- vm_minimal_C2:
+    app: vm_minimal
+    platform: ODROID_C2
 - vm_serial_server_ODROID_XU4:
     app: vm_serial_server
     platform: ODROID_XU4


### PR DESCRIPTION
Seems the hardware run for ODROID_C2 passes also, so we can add this

See https://github.com/seL4/camkes-vm-examples/actions/runs/7676645400/job/20924491718?pr=59 where I have it as 
`vm_minimal_ODROID_C2`