### PR TITLE
camkes-vm: use full name for ODROID_C2

### DIFF
--- a/camkes-vm/builds.yml
+++ b/camkes-vm/builds.yml
@@ -65,7 +65,7 @@ builds:
     platform: TX2
     settings:
         NUM_NODES: 4
-- vm_minimal_C2:
+- vm_minimal_ODROID_C2:
     app: vm_minimal
     platform: ODROID_C2
 - vm_serial_server_ODROID_XU4:


### PR DESCRIPTION
Align with the other board names, use the full name