### PR TITLE
platforms: revert custom settings

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -120,9 +120,9 @@ platforms:
     march: armv8a
     no_hw_build: true
     # The MaaxBoard in machine queue expects a binary image
-    settings:
-        Sel4testAllowSettingsOverride: true
-        ElfloaderImage: "binary"
+    # settings:
+    # Sel4testAllowSettingsOverride: true
+    # ElfloaderImage: "binary"
 
   IMX8MM_EVK:
     arch: arm
@@ -225,9 +225,9 @@ platforms:
     req: [zcu102_2]
     march: armv8a
     # The ZCU102 in machine queue expects a binary image
-    settings:
-        Sel4testAllowSettingsOverride: true
-        ElfloaderImage: "binary"
+    # settings:
+    # Sel4testAllowSettingsOverride: true
+    # ElfloaderImage: "binary"
 
   ZYNQMP106:
     arch: arm


### PR DESCRIPTION
Reverts some of the changes in
https://github.com/seL4/ci-actions/pull/310 that lead to unexpected side-affects. The 'Sel4testAllowSettingsOverride' prevents any default settings being applied in addition to allowing the settings to be overriden.