### PR TITLE
platforms: switch to different odroidxu4 board

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -204,7 +204,7 @@ platforms:
     modes: [32]
     aarch_hyp: [32]
     platform: exynos5422
-    req: [odroidxu4_1]
+    req: [odroidxu4_2]
     image_platform: exynos5
     march: armv7a
 


### PR DESCRIPTION
The odroidxu4_1 seems to have too many flaky tests. Check if this changes with a different board.
