### PR TITLE
camkes-vm: add vm_minimal_smp_ZCU102_2022_1

### DIFF
--- a/camkes-vm/builds.yml
+++ b/camkes-vm/builds.yml
@@ -62,6 +62,14 @@ builds:
     success: "@xilinx-zcu102"
     settings:
         VmZynqmpPetalinuxVersion: '2022_1'
+- vm_minimal_smp_ZCU102_2022_1:
+    app: vm_minimal
+    platform: ZYNQMP
+    vm_platform: zcu102
+    success: "@xilinx-zcu102"
+    settings:
+        VmZynqmpPetalinuxVersion: '2022_1'
+        NUM_NODES: 4
 - vm_minimal_ARMVIRT32:
     app: vm_minimal
     platform: ARMVIRT32


### PR DESCRIPTION
Adding a CI run with SMP enabled for ZCU102. Looks like this is is also working for the minimal example:

```
  ELF-loader started on CPU: ARM Ltd. Cortex-A53 r0p4
...
  Boot cpu id = 0x0, index=0
  Core 1 is up with logic id 1
  Core 2 is up with logic id 2
  Core 3 is up with logic id 3
  Enabling hypervisor MMU and paging
  Jumping to kernel-image entry point...
  Warning:  gpt_cntfrq 99990008, expected 100000000
  Bootstrapping kernel
...
  WWWaaarrrnnniiinnnggg:::      gggpppttt___cccnnntttfffrrrqqq   999999999999000000000888,,,   eeexxxpppeeecccttteeeddd   111000000000000000000000000
  Booting all finished, dropped to user space
...
  [    0.000000] Linux version 5.15.19-xilinx-v2022.1 (oe-user@oe-host) (aarch64-xilinx-linux-gcc (GCC) 11.2.0, GNU ld (GNU Binutils) 2.37.20210721) #1 SMP Mon Apr 11 17:52:14 UTC 2022
...
  [    0.051550] smp: Bringing up secondary CPUs ...
  [    0.056261] Detected VIPT I-cache on CPU1
  [    0.056590] CPU1: Booted secondary processor 0x0000000003 [0x410fd034]
  [    0.057054] Detected VIPT I-cache on CPU2
  [    0.057[368] CPU2: Booted secondary processor 0x0000000002 [0x410fd034]
  [    0.057798] Detected VIPT I-cache on CPU3
  [    0.058112] CPU3: Booted secondary processor 0x0000000001 [0x410fd034]
  [    0.058238] smp: Brought up 1 node, 4 CPUs
...
PetaLinux 2022.1_release_S04190222 xilinx-zcu102-20221 ttyPS0
```