### PR TITLE
platforms: add polarfire hardware build

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -67,6 +67,14 @@ platforms:
     req: [hifive] # , hifive1]
     march: rv64imac
 
+  POLARFIRE:
+    arch: riscv
+    modes: [64]
+    smp: [64]
+    platform: polarfire
+    march: rv64imac
+    no_hw_test: true
+
   SABRE:
     arch: arm
     modes: [32]


### PR DESCRIPTION
Ideally we'd also add simulation support, which first needs updates in the `simulate.py` script in [seL4_tools](https://github.com/seL4/seL4_tools). qemu seems to have support for it: <https://www.qemu.org/docs/master/system/riscv/microchip-icicle-kit.html>

I had a first go at that, but didn't get any output from qemu, so I'm leaving it out for now.

Adds one of the platforms listed in #282