### PR TITLE
add ARMVIRT32 platform

### DIFF
--- a/camkes-vm/builds.yml
+++ b/camkes-vm/builds.yml
@@ -62,9 +62,9 @@ builds:
     success: "@xilinx-zcu102"
     settings:
         VmZynqmpPetalinuxVersion: '2022_1'
-- vm_minimal_ARMVIRT:
+- vm_minimal_ARMVIRT64:
     app: vm_minimal
-    platform: ARMVIRT
+    platform: ARMVIRT64
     sim: true
 - vm_minimal_ODROID_XU4:
     app: vm_minimal
@@ -128,7 +128,7 @@ builds:
 - vm_introspect_ODROID_XU4:
     app: vm_introspect
     platform: ODROID_XU4
-- vm_introspect_ARMVIRT:
+- vm_introspect_ARMVIRT64:
     app: vm_introspect
-    platform: ARMVIRT
+    platform: ARMVIRT64
     sim: true

--- a/camkes-vm/builds.yml
+++ b/camkes-vm/builds.yml
@@ -62,6 +62,10 @@ builds:
     success: "@xilinx-zcu102"
     settings:
         VmZynqmpPetalinuxVersion: '2022_1'
+- vm_minimal_ARMVIRT32:
+    app: vm_minimal
+    platform: ARMVIRT32
+    sim: true
 - vm_minimal_ARMVIRT64:
     app: vm_minimal
     platform: ARMVIRT64

--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -100,6 +100,15 @@ platforms:
     march: armv8a
     no_hw_test: true
 
+  ARMVIRT32:
+    arch: arm
+    modes: [32]
+    platform: qemu-arm-virt
+    has_simulation: true
+    march: armv7a # Cortex-A15 is emulated by default
+    no_hw_test: true
+    no_hw_build: true
+
   ARMVIRT64:
     arch: arm
     modes: [64]

--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -100,7 +100,7 @@ platforms:
     march: armv8a
     no_hw_test: true
 
-  ARMVIRT:
+  ARMVIRT64:
     arch: arm
     modes: [64]
     platform: qemu-arm-virt

--- a/webserver/builds.yml
+++ b/webserver/builds.yml
@@ -13,7 +13,7 @@ builds:
     platform: ODROID_XU4
 
 - qemu-arm-virt:
-    platform: ARMVIRT
+    platform: ARMVIRT64
 
 - odroid_c2:
     platform: ODROID_C2


### PR DESCRIPTION
This PR adds a AARCH32 QEMU platform. I am not sure how useful this is practically, given we have ARMv8 now and there might be less and less interest in ARMv7 support. We are testing the kernel on the QEMU/sabre simulation and the VM examples seem broken/neglected (https://github.com/seL4/camkes-vm-examples/issues/73). So there is not much use, except for some experimenting. And ensuring CI can hande the QEMU flexibility, as we need this for RISC-V then also.