### PR TITLE
builds.py: let mq lock be reclaimed after 30min

### DIFF
--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -451,8 +451,8 @@ def mq_run(success_str: str,
 
 
 def mq_lock(machine: str) -> List[str]:
-    """Get lock for a machine."""
-    return ['time', 'mq.sh', 'sem', '-wait', machine, '-k', job_key()]
+    """Get lock for a machine. Allow lock to be reclaimed after 30min."""
+    return ['time', 'mq.sh', 'sem', '-wait', machine, '-k', job_key(), '-T', '1800']
 
 
 def mq_release(machine: str) -> List[str]:


### PR DESCRIPTION
A typical job takes about 5-10 min. If the lock has been held for 30 min in a single job, we assume something has gone wrong and the lock should be released so other jobs (or humans needing the machine) can proceed.