### PR TITLE
simulation: signal failure on timeout

### DIFF
--- a/camkes-vm/build.py
+++ b/camkes-vm/build.py
@@ -8,7 +8,7 @@ Parse builds.yml and run CAmkES VM test on each of the build definitions.
 Expects seL4-platforms/ to be co-located or otherwise in the PYTHONPATH.
 """
 
-from builds import Build, run_build_script, run_builds, load_builds, release_mq_locks, SKIP
+from builds import Build, run_build_script, run_builds, load_builds, release_mq_locks, SKIP, sim_script
 from pprint import pprint
 
 import os
@@ -44,10 +44,7 @@ def run_build(manifest_dir: str, build: Build):
     ]
 
     if plat.has_simulation and plat.name != 'PC99':
-        script.append(
-            ["bash", "-c",
-             f"expect -c 'spawn ./simulate; set timeout 3000; expect \"{build.success}\"'"]
-        )
+        script.append(sim_script(build.success))
 
     return run_build_script(manifest_dir, build, script)
 

--- a/rump-hello/build.py
+++ b/rump-hello/build.py
@@ -8,7 +8,7 @@ Parse builds.yml and run rumprun test on each of the build definitions.
 Expects seL4-platforms/ to be co-located or otherwise in the PYTHONPATH.
 """
 
-from builds import Build, run_build_script, run_builds, load_builds
+from builds import Build, run_build_script, run_builds, load_builds, sim_script
 from builds import release_mq_locks, SKIP
 from pprint import pprint
 
@@ -32,10 +32,7 @@ def run_build(manifest_dir: str, build: Build):
     ]
 
     if build.req == 'sim':
-        script.append(
-            ["bash", "-c",
-             f"expect -c 'spawn ./simulate; set timeout 3000; expect \"{build.success}\"'"]
-        )
+        script.append(sim_script(build.success))
     else:
         script.append(["tar", "czf", f"../{build.name}-images.tar.gz", "images/"])
 

--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -27,7 +27,8 @@ import sys
 
 # exported names:
 __all__ = [
-    "Build", "load_builds", "run_builds", "run_build_script", "junit_results", "sanitise_junit"
+    "Build", "load_builds", "run_builds", "run_build_script", "junit_results", "sanitise_junit",
+    "sim_script"
 ]
 
 # where to expect jUnit results by default
@@ -550,6 +551,14 @@ parsed_junit_results = 'parsed_results.xml'
 # expects to run in build dir of a standard seL4 project setup
 sanitise_junit = ["python3", "../projects/seL4_libs/libsel4test/tools/extract_results.py",
                   "-q", junit_results, parsed_junit_results]
+
+
+def sim_script(success: str, timeout=1200):
+    return [
+        "expect", "-c",
+        'spawn ./simulate; set timeout %d; expect { "%s" {exit 0} timeout {exit 1} }' %
+        (timeout, success)
+    ]
 
 
 def run_build_script(manifest_dir: str,

--- a/sel4test-sim/build.py
+++ b/sel4test-sim/build.py
@@ -18,13 +18,13 @@ import sys
 def run_simulation(manifest_dir: str, build: Build):
     """Run one simulation build and test."""
 
-    expect = f"\"{build.success}\""
+    expect = '{ "%s" {exit 0} timeout {exit 1} }' % build.success
 
     script = [
         ["../init-build.sh"] + build.settings_args(),
         ["ninja"],
         ["bash", "-c",
-         f"expect -c 'spawn ./simulate; set timeout 3000; expect {expect}' | tee {junit_results}"]
+         f"expect -c 'spawn ./simulate; set timeout 1200; expect {expect}' | tee {junit_results}"]
     ]
 
     return run_build_script(manifest_dir, build, script, junit=True)

--- a/webserver/build.py
+++ b/webserver/build.py
@@ -8,7 +8,7 @@ Parse builds.yml and run the seL4 web server app build/test on each of the build
 Expects seL4-platforms/ to be co-located or otherwise in the PYTHONPATH.
 """
 
-from builds import Build, run_build_script, run_builds, load_builds, release_mq_locks, SKIP
+from builds import Build, run_build_script, run_builds, load_builds, release_mq_locks, SKIP, sim_script
 from pprint import pprint
 
 import os
@@ -36,10 +36,7 @@ def run_build(manifest_dir: str, build: Build):
     ]
 
     if plat.has_simulation and plat.name != 'PC99':
-        script.append(
-            ["bash", "-c",
-             f"expect -c 'spawn ./simulate; set timeout 3000; expect \"{build.success}\"'"]
-        )
+        script.append(sim_script(build.success))
 
     return run_build_script(manifest_dir, build, script)
 


### PR DESCRIPTION
Return exit code 0 on expected success string, and exit code 1 on timeout for all simulation scripts. Reduce standard timeout to 20min.

Previously, failure to produce the success string would lead to a timeout which did not signal a test failure and would just continue on to the next test.