### PR TITLE
simulation: fix expect script; add failure string

### DIFF
--- a/camkes-vm/build.py
+++ b/camkes-vm/build.py
@@ -44,7 +44,7 @@ def run_build(manifest_dir: str, build: Build):
     ]
 
     if plat.has_simulation and plat.name != 'PC99':
-        script.append(sim_script(build.success))
+        script.append(sim_script(build.success, failure=build.error))
 
     return run_build_script(manifest_dir, build, script)
 

--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -553,11 +553,14 @@ sanitise_junit = ["python3", "../projects/seL4_libs/libsel4test/tools/extract_re
                   "-q", junit_results, parsed_junit_results]
 
 
-def sim_script(success: str, timeout=1200):
+def sim_script(success: str, failure=None, timeout=1200):
+    """Return a script to run a simulation with timeout and expected success string.
+       Abort early on expected failure string."""
+    fail_str = "%s {exit 1}" % failure if failure else ""
     return [
         "expect", "-c",
-        'spawn ./simulate; set timeout %d; expect { "%s" {exit 0} timeout {exit 1} }' %
-        (timeout, success)
+        'spawn ./simulate; set timeout %d; expect "%s" {exit 0} %s timeout {exit 1}' %
+        (timeout, fail_str, success)
     ]
 
 

--- a/sel4test-sim/build.py
+++ b/sel4test-sim/build.py
@@ -18,7 +18,7 @@ import sys
 def run_simulation(manifest_dir: str, build: Build):
     """Run one simulation build and test."""
 
-    expect = '{ "%s" {exit 0} timeout {exit 1} }' % build.success
+    expect = '"%s" {exit 0} timeout {exit 1}' % build.success
 
     script = [
         ["../init-build.sh"] + build.settings_args(),


### PR DESCRIPTION
- the syntax for the expect script wasn't quite right; now fixed.
- add a failure string for early abort where the builds support that.

This should now close #339 and fix the problem introduced in #340.