### PR TITLE
camkes-vm: remove unsupported ARMVIRT32 build

### DIFF
--- a/camkes-vm/builds.yml
+++ b/camkes-vm/builds.yml
@@ -70,10 +70,6 @@ builds:
     settings:
         VmZynqmpPetalinuxVersion: '2022_1'
         NUM_NODES: 4
-- vm_minimal_ARMVIRT32:
-    app: vm_minimal
-    platform: ARMVIRT32
-    sim: true
 - vm_minimal_ARMVIRT64:
     app: vm_minimal
     platform: ARMVIRT64


### PR DESCRIPTION
ARMVIRT32 is currently not supported in the VM, and there are no immediate plans to change that since work is focused on 64 bit VMMs.

This resolves [seL4/camkes-vm](https://github.com/seL4/camkes-vm-examples/issues/73).

See also https://github.com/seL4/camkes-vm-examples/pull/74