### PR TITLE
aws-proofs: switch to us-east-1 region

### DIFF
--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -22,7 +22,7 @@ echo "::group::AWS"
 # fail on any error
 set -e
 
-aws configure set default.region us-east-2
+aws configure set default.region us-east-1
 aws configure set default.output json
 
 echo "Starting AWS instance..."


### PR DESCRIPTION
us-east-1 has a lower interrupt rate for our VM class than use-east-2, and currently same price.