### PR TITLE
python: remove broken unused function

### DIFF
--- a/seL4-platforms/platforms.py
+++ b/seL4-platforms/platforms.py
@@ -160,9 +160,6 @@ class Platform:
     def cmake_toolchain_setting(self, mode: int) -> str:
         return self.toolchain_arch_str() + str(mode)
 
-    def settings(self) -> str:
-        return self.settings
-
     def get_image_platform(self, mode: int) -> str:
         return self.image_platform or self.get_platform(mode)
 


### PR DESCRIPTION
Commit 85c8f71d should never have added this function, it slipped the review, The function's type annotation is broken, it returns a dict and not a string. Furthermore, there is not need for this wrapper, as we can (and do) read the attribute directly. Nobody uses this function, so let's just remove it.



