### PR TITLE
github: repository_dispatch trigger on deps-update

### DIFF
--- a/.github/workflows/deploy-camkes-test.yml
+++ b/.github/workflows/deploy-camkes-test.yml
@@ -15,6 +15,9 @@ on:
     - 'seL4-platforms/**'
     - 'camkes-test/**'
   workflow_dispatch:
+  # allow explict trigger from other repos when dependencies have changed
+  repository_dispatch:
+    types: [deps-update]
 
 jobs:
   docker:

--- a/.github/workflows/deploy-camkes-unit.yml
+++ b/.github/workflows/deploy-camkes-unit.yml
@@ -14,6 +14,9 @@ on:
     - 'scripts/**'
     - 'camkes-unit/**'
   workflow_dispatch:
+  # allow explict trigger from other repos when dependencies have changed
+  repository_dispatch:
+    types: [deps-update]
 
 jobs:
   docker:

--- a/.github/workflows/deploy-camkes-vm.yml
+++ b/.github/workflows/deploy-camkes-vm.yml
@@ -15,6 +15,9 @@ on:
     - 'seL4-platforms/**'
     - 'camkes-vm/**'
   workflow_dispatch:
+  # allow explict trigger from other repos when dependencies have changed
+  repository_dispatch:
+    types: [deps-update]
 
 jobs:
   docker:

--- a/.github/workflows/deploy-cparser-builder.yml
+++ b/.github/workflows/deploy-cparser-builder.yml
@@ -24,7 +24,7 @@ on:
     - 'cparser-run/**'
     - 'preprocess/**'
   repository_dispatch:
-    types: [cparser-deploy]
+    types: [cparser-deploy, deps-update]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-cparser-run.yml
+++ b/.github/workflows/deploy-cparser-run.yml
@@ -9,7 +9,7 @@ name: Deploy CParser Run
 on:
   # the real build trigger is in deploy-cparser-builder
   repository_dispatch:
-    types: [cparser-build]
+    types: [cparser-build, deps-update]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-preprocess.yml
+++ b/.github/workflows/deploy-preprocess.yml
@@ -9,7 +9,7 @@ name: Deploy Preprocess Test
 on:
   # the real build trigger is in deploy-cparser-builder
   repository_dispatch:
-    types: [cparser-build]
+    types: [cparser-build, deps-update]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-rumprun.yml
+++ b/.github/workflows/deploy-rumprun.yml
@@ -15,6 +15,9 @@ on:
     - 'seL4-platforms/**'
     - 'rump-hello/**'
   workflow_dispatch:
+  # allow explict trigger from other repos when dependencies have changed
+  repository_dispatch:
+    types: [deps-update]
 
 jobs:
   docker:

--- a/.github/workflows/deploy-run-proofs.yml
+++ b/.github/workflows/deploy-run-proofs.yml
@@ -14,6 +14,9 @@ on:
     - 'scripts/**'
     - 'run-proofs/**'
   workflow_dispatch:
+  # allow explict trigger from other repos when dependencies have changed
+  repository_dispatch:
+    types: [deps-update]
 
 jobs:
   docker:

--- a/.github/workflows/deploy-sel4bench.yml
+++ b/.github/workflows/deploy-sel4bench.yml
@@ -15,6 +15,9 @@ on:
     - 'seL4-platforms/**'
     - 'sel4bench/**'
   workflow_dispatch:
+  # allow explict trigger from other repos when dependencies have changed
+  repository_dispatch:
+    types: [deps-update]
 
 jobs:
   docker:

--- a/.github/workflows/deploy-sel4test-hw.yml
+++ b/.github/workflows/deploy-sel4test-hw.yml
@@ -15,6 +15,9 @@ on:
     - 'seL4-platforms/**'
     - 'sel4test-hw/**'
   workflow_dispatch:
+  # allow explict trigger from other repos when dependencies have changed
+  repository_dispatch:
+    types: [deps-update]
 
 jobs:
   docker:

--- a/.github/workflows/deploy-sel4test-sim.yml
+++ b/.github/workflows/deploy-sel4test-sim.yml
@@ -15,6 +15,9 @@ on:
     - 'seL4-platforms/**'
     - 'sel4test-sim/**'
   workflow_dispatch:
+  # allow explict trigger from other repos when dependencies have changed
+  repository_dispatch:
+    types: [deps-update]
 
 jobs:
   docker:

--- a/.github/workflows/deploy-tutorials.yml
+++ b/.github/workflows/deploy-tutorials.yml
@@ -15,6 +15,9 @@ on:
     - 'seL4-platforms/**'
     - 'tutorials/**'
   workflow_dispatch:
+  # allow explict trigger from other repos when dependencies have changed
+  repository_dispatch:
+    types: [deps-update]
 
 jobs:
   docker:

--- a/.github/workflows/deploy-webserver.yml
+++ b/.github/workflows/deploy-webserver.yml
@@ -15,6 +15,9 @@ on:
     - 'seL4-platforms/**'
     - 'webserver/**'
   workflow_dispatch:
+  # allow explict trigger from other repos when dependencies have changed
+  repository_dispatch:
+    types: [deps-update]
 
 jobs:
   docker:


### PR DESCRIPTION
Allow remote repositories to trigger container deployment on this repo with the `deps-update` payload. The intention is for this to be used from the seL4-CAmkES-L4v-Dockerfiles repo when the base docker images are updated.