### PR TITLE
allow other manifests in l4v-deploy

### DIFF
--- a/l4v-deploy/common.py
+++ b/l4v-deploy/common.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2020, Data61, CSRIO
+# Copyright 2020, Data61, CSIRO
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # Common utils.

--- a/l4v-deploy/seL4-pp
+++ b/l4v-deploy/seL4-pp
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright 2020, Data61, CSRIO
+# Copyright 2020, Data61, CSIRO
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # This is a post-build deploy script for the “seL4 preprocess” build.
@@ -16,13 +16,12 @@
 
 import argparse
 import os
-import re
 import subprocess
 import sys
 from xml.dom import minidom
 
 # Local imports
-from common import *
+from common import run_command, loud_command, indent, set_repo_email, format_commit_message
 
 parser = argparse.ArgumentParser("Update seL4 revision in verification-manifest from CI",
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/l4v-deploy/staging-manifest
+++ b/l4v-deploy/staging-manifest
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright 2020, Data61, CSRIO
+# Copyright 2020, Data61, CSIRO
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # If the l4v tests succeeded, write this version to default.xml
@@ -26,7 +26,7 @@ import sys
 import tempfile
 
 # Local imports
-from common import *
+from common import run_command, loud_command, indent, set_repo_email, format_commit_message
 
 parser = argparse.ArgumentParser("Auto-update verification manifest from CI",
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/l4v-deploy/steps.sh
+++ b/l4v-deploy/steps.sh
@@ -22,12 +22,21 @@ echo "::endgroup::"
 
 if [ -z "${INPUT_PREPROCESS}" ]
 then
-  # As a safeguard, we insist that INPUT_MANIFEST is
-  # only set for preprocess updates.
-  if [ -n "${INPUT_MANIFEST}" ]
+  # For deployment after test, we can only deal with the default devel.xml and a
+  # potentially provided mcs-devel.xml, but no other input manifests.
+  if [ -n "${INPUT_MANIFEST}" ] && [ "${INPUT_MANIFEST}" != "mcs-devel.xml" ]
   then
-    echo "Error: INPUT_MANIFEST was set for a non-preprocess deployment" >&2
+    echo "Error: INPUT_MANIFEST was set, but not mcs-devel.xml for a non-preprocess deployment" >&2
     exit 1
+  fi
+
+  if [ "${INPUT_MANIFEST}" == "mcs-devel.xml" ]; then
+    # for checkout-manifest.sh; read input from mcs-devel.xml
+    export REPO_MANIFEST="$INPUT_MANIFEST"
+    # deploy hashes to mcs.xml
+    declare -a MANIFEST_FILE=("--manifest-file" "mcs.xml")
+  else
+    declare -a MANIFEST_FILE
   fi
 
   echo "::group::Repo checkout"
@@ -43,10 +52,13 @@ then
   echo "::endgroup::"
 
   echo "::group::Deploy"
-  staging-manifest ssh://git@github.com/seL4/verification-manifest.git
+  staging-manifest "${MANIFEST_FILE[@]}" ssh://git@github.com/seL4/verification-manifest.git
   echo "::endgroup::"
 else
   if [ -n "${INPUT_MANIFEST}" ]; then
+    # for checkout-manifest.sh
+    export REPO_MANIFEST="$INPUT_MANIFEST"
+    # for sel4-pp
     declare -a MANIFEST_FILE=("--manifest-file" "${INPUT_MANIFEST}")
   else
     declare -a MANIFEST_FILE


### PR DESCRIPTION
Add mechanism for deploying after preprocess and after proof test to manifests other than `devel.xml`/`default.xml`. Currently only `mcs-devel.xml`/`mcs.xml` are allowed.
