### PR TITLE
sel4test-hw: temporarily pin docker base image

### DIFF
--- a/sel4test-hw/Dockerfile
+++ b/sel4test-hw/Dockerfile
@@ -8,7 +8,7 @@ ARG WORKSPACE=/workspace
 ARG SCRIPTS=/ci-scripts
 ARG ACTION=sel4test-hw
 
-FROM trustworthysystems/sel4:latest
+FROM trustworthysystems/sel4:2024_07_11
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Base images since 2024-07-19 produce sel4test images with new failures for imx8mm-evk and odroid_c4. Pin to the version before that to enable continued development for now.

The intention is to revert this commit once we have figured out what has changed in the build container to make the tests fail.