### PR TITLE
builds: exclude clang + hyp + smp for zynqmp

### DIFF
--- a/sel4test-hw/build.py
+++ b/sel4test-hw/build.py
@@ -79,9 +79,10 @@ def build_filter(build: Build) -> bool:
             return False
 
         # HYP/SMP exclusions:
-        # IMX8MQ_EVK is failing multicore tests for SMP + HYP + clang
+        # IMX8MQ_EVK and ZYNQMPs are failing multicore tests for SMP + HYP + clang
         # see also https://github.com/seL4/sel4test/issues/44
-        if plat.name == 'IMX8MQ_EVK' and build.is_hyp() and build.is_smp() and build.is_clang():
+        if plat.name in ['IMX8MQ_EVK', 'ZYNQMP', 'ZYNQMP106'] and \
+           build.is_hyp() and build.is_smp() and build.is_clang():
             return False
 
     if plat.arch == 'x86':


### PR DESCRIPTION
The recently enabled hyp tests for `zynqmp` don't work with `clang` and `SMP` configs, so exclude these again for now.

This is most likely another instance of https://github.com/seL4/sel4test/issues/44