### PR TITLE
camkes-vm: avoid exception when BAMBOO is not set

### DIFF
--- a/camkes-vm/build.py
+++ b/camkes-vm/build.py
@@ -28,7 +28,8 @@ def run_build(manifest_dir: str, build: Build):
 
     build.files = plat.image_names(build.get_mode(), "capdl-loader")
     build.settings['CAMKES_VM_APP'] = build.app or build.name
-    del build.settings['BAMBOO']    # not used in this test, avoid warning
+    if 'BAMBOO' in build.settings:
+        del build.settings['BAMBOO']    # not used in this test, avoid warning
 
     if plat.arch == 'x86':
         del build.settings['PLATFORM']  # not used for x86 in this test, avoid warning


### PR DESCRIPTION
Since we are enumerating builds, it is possible that BAMBOO is not set, leading to an exception when deleting this (unused) key. Therefore check for presence before deleting.

(#361 broke the camkes-vm build because of this)