### PR TITLE
disable more zynqmp 32 tests

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -237,7 +237,7 @@ platforms:
     arch: arm
     modes: [32, 64]
     smp: [64]
-    aarch_hyp: [32, 64]
+    aarch_hyp: [64]
     platform: zynqmp
     req: [zcu102_2]
     march: armv8a
@@ -250,7 +250,7 @@ platforms:
     arch: arm
     modes: [32, 64]
     smp: [64]
-    aarch_hyp: [32, 64]
+    aarch_hyp: [64]
     platform: zynqmp
     req: [zcu106]
     march: armv8a

--- a/sel4test-hw/build.py
+++ b/sel4test-hw/build.py
@@ -85,6 +85,10 @@ def build_filter(build: Build) -> bool:
            build.is_hyp() and build.is_smp() and build.is_clang():
             return False
 
+        # zynqmp 32 does not work with MCS
+        if plat.name == 'ZYNQMP' and build.get_mode() == 32 and build.is_mcs():
+            return False
+
     if plat.arch == 'x86':
         # Bamboo config says no VTX for SMP or verification
         if build.is_hyp() and (build.is_smp() or build.is_verification()):


### PR DESCRIPTION
- `hyp` doesn't work in 32 bit mode yet, possibly just needs some setup from the elf loader, but disabling for now, since we really only need the non-hyp version at the moment

-  `MCS` doesn't work in 32-bit mode on the zcu102, stopping with assertion failure at boot (but interestingly does work on the zcu106). Disabling for now.