### PR TITLE
sel4test-hw: un-pin upstream image version

### DIFF
--- a/sel4test-hw/Dockerfile
+++ b/sel4test-hw/Dockerfile
@@ -8,7 +8,7 @@ ARG WORKSPACE=/workspace
 ARG SCRIPTS=/ci-scripts
 ARG ACTION=sel4test-hw
 
-FROM trustworthysystems/sel4:2024_07_11
+FROM trustworthysystems/sel4:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This reverts commit dfd143c1eb3dd5ac4c4445084aef0f82f2c9821e.

The failures mentioned in this commit have (hopefully) been resolved, and we want to pick up the switch to clang-12.