### PR TITLE
sel4test: temporarily remove riscv/clang

### DIFF
--- a/sel4test-hw/builds.yml
+++ b/sel4test-hw/builds.yml
@@ -17,3 +17,9 @@ variants:
     # domains: ['', DOM]
     compiler: [gcc, clang]
     mode: [32, 64]
+
+build-filter:
+    - arch: [arm, x86]
+    - arch: [riscv]
+      # remove riscv clang for now, until muslibc is working with clang-12
+      compiler: gcc

--- a/sel4test-sim/builds.yml
+++ b/sel4test-sim/builds.yml
@@ -48,6 +48,8 @@ build-filter:
       arch: [riscv]
       # Bamboo has no "release" simulation for RISCV, and it doesn't seem to work either:
       debug: [debug]
+      # remove riscv clang for now, until muslibc is working with clang-12
+      compiler: gcc
 
 
 # A build-filter is a list of dicts. A build passes the filter if it passes any


### PR DESCRIPTION
Temporarily remove riscv/clang until it works with clang-12.