### PR TITLE
sel4test: re-enable riscv+clang

### DIFF
--- a/sel4test-hw/builds.yml
+++ b/sel4test-hw/builds.yml
@@ -17,9 +17,3 @@ variants:
     # domains: ['', DOM]
     compiler: [gcc, clang]
     mode: [32, 64]
-
-build-filter:
-    - arch: [arm, x86]
-    - arch: [riscv]
-      # remove riscv clang for now, until muslibc is working with clang-12
-      compiler: gcc

--- a/sel4test-sim/builds.yml
+++ b/sel4test-sim/builds.yml
@@ -48,8 +48,6 @@ build-filter:
       arch: [riscv]
       # Bamboo has no "release" simulation for RISCV, and it doesn't seem to work either:
       debug: [debug]
-      # remove riscv clang for now, until muslibc is working with clang-12
-      compiler: gcc
 
 
 # A build-filter is a list of dicts. A build passes the filter if it passes any


### PR DESCRIPTION
The clang-12 experiment did not work out, and the base images are back on clang-11 which does support our riscv builds.

This reverts commit 44091837d5d02c6c275c9c3348474991360e93b6.

Needs https://github.com/seL4/seL4-CAmkES-L4v-dockerfiles/pull/89 to be merged first.