### PR TITLE
aws: change region

### DIFF
--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -22,7 +22,7 @@ echo "::group::AWS"
 # fail on any error
 set -e
 
-aws configure set default.region us-east-1
+aws configure set default.region ap-southeast-4
 aws configure set default.output json
 
 echo "Starting AWS instance..."


### PR DESCRIPTION
Spot instance interrupt frequency got very high on us-east-1. Try ap-southeast-4 which currently has low interrupt rate and good pricing.