### PR TITLE
fix setuptools version

### DIFF
--- a/scripts/install-python.sh
+++ b/scripts/install-python.sh
@@ -11,4 +11,4 @@ sudo apt-get install -qq python3.10 > /dev/null
 sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1
 sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
 python3 --version
-pip3 install -q --upgrade pip setuptools launchpadlib wheel
+pip3 install -q --upgrade pip setuptools==70.0.0 launchpadlib wheel


### PR DESCRIPTION
`sel4-deps` have started to fail installation on GitHub CI, although they seem to work fine on clean Ubuntu 22.04.

See also the saga on https://github.com/pypa/setuptools/issues/4483 -- fixing the version of `setuptools` seems to fix the problem for CI.