### PR TITLE
platforms.yml: fix RISC-V march

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -37,7 +37,7 @@ platforms:
     modes: [64]
     platform: spike
     has_simulation: true
-    march: rv64imac
+    march: rv64imafdc
     no_hw_test: true
     no_hw_build: true
 
@@ -46,7 +46,7 @@ platforms:
     modes: [64]
     platform: qemu-riscv-virt
     has_simulation: true
-    march: rv64imac
+    march: rv64imafdc
     no_hw_test: true
     no_hw_build: true
 
@@ -65,14 +65,14 @@ platforms:
     smp: [64]
     platform: hifive
     req: [hifive] # , hifive1]
-    march: rv64imac
+    march: rv64imafdc
 
   POLARFIRE:
     arch: riscv
     modes: [64]
     smp: [64]
     platform: polarfire
-    march: rv64imac
+    march: rv64imafdc
     no_hw_test: true
 
   SABRE:


### PR DESCRIPTION
I think this is only used for the name of the CI job and nothing else. Now that the kernel defaults to FPU support on for RISC-V, we should probably change all of these to reflect that.