### PR TITLE
platforms.yml: remove cheshire support

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -30,13 +30,6 @@ platforms:
     march: rv64imac
     no_hw_test: true
 
-  CHESHIRE:
-    arch: riscv
-    modes: [64]
-    platform: cheshire
-    march: rv64imac
-    no_hw_test: true
-
   SPIKE32:
     arch: riscv
     modes: [32]


### PR DESCRIPTION
My bad, Cheshire doesn't have a timer so sel4bench can't build which means that we can't have it in platforms.yml