### PR TITLE
sel4bench workflow: add option for always building

### DIFF
--- a/.github/workflows/sel4bench-hw.yml
+++ b/.github/workflows/sel4bench-hw.yml
@@ -8,6 +8,12 @@ name: seL4Bench-HW
 
 on:
   workflow_call:
+    inputs:
+      always_build:
+        description: 'Always build sel4bench images, even if no label is present'
+        required: false
+        default: false
+        type: boolean
 
 # intended to run on
 #  pull_request_target:
@@ -26,10 +32,10 @@ jobs:
 # restart tests ("contains" clause), even if the event is for adding a different
 # label.
     if: ${{ github.event_name == 'pull_request_target' &&
-            (
-              contains(github.event.pull_request.labels.*.name, 'hw-bench') ||
-              github.event.label.name == 'hw-bench'
-            ) }}
+            ((
+               contains(github.event.pull_request.labels.*.name, 'hw-bench') ||
+               github.event.label.name == 'hw-bench'
+             ) || inputs.always_build) }}
     outputs:
       xml: ${{ steps.repo.outputs.xml }}
     steps:
@@ -67,7 +73,13 @@ jobs:
 
   hw-run:
     name: HW Benchmark
-    if: ${{ github.repository_owner == 'seL4' }}
+    if: ${{ github.repository_owner == 'seL4' &&
+            github.event_name == 'pull_request_target' &&
+            (
+              contains(github.event.pull_request.labels.*.name, 'hw-bench') ||
+              github.event.label.name == 'hw-bench'
+            )
+        }}
     runs-on: ubuntu-latest
     needs: [build]
     concurrency:


### PR DESCRIPTION
Add an option for always building the sel4bench images, e.g. without labelling. Useful for PR checks on the sel4bench repo itself.