### PR TITLE
github: option access token for private repos

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,14 @@
 
 name: PR
 
-on: [pull_request, workflow_call]
+on:
+  pull_request:
+  workflow_call:
+    secrets:
+      token:
+        description: 'Optional token for private repositories'
+        required: false
+
 
 jobs:
   gitlint:
@@ -14,21 +21,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: seL4/ci-actions/gitlint@master
+      with:
+        token: ${{ secrets.token }}
 
   whitespace:
     name: 'Trailing Whitespace'
     runs-on: ubuntu-latest
     steps:
     - uses: seL4/ci-actions/git-diff-check@master
+      with:
+        token: ${{ secrets.token }}
 
   shell:
     name: 'Portable Shell'
     runs-on: ubuntu-latest
     steps:
     - uses: seL4/ci-actions/bashisms@master
+      with:
+        token: ${{ secrets.token }}
 
   style:
     name: Style
     runs-on: ubuntu-22.04
     steps:
     - uses: seL4/ci-actions/style@master
+      with:
+        token: ${{ secrets.token }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,6 +11,10 @@ on:
       - master
   pull_request:
   workflow_call:
+    secrets:
+      token:
+        description: 'Optional token for private repositories'
+        required: false
 
 jobs:
   check:
@@ -18,9 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: seL4/ci-actions/license-check@master
+      with:
+        token: ${{ secrets.token }}
 
   links:
     name: Links
     runs-on: ubuntu-latest
     steps:
       - uses: seL4/ci-actions/link-check@master
+        with:
+          token: ${{ secrets.token }}


### PR DESCRIPTION
Input option for providing an access token for read-access, so that the checks can also work on private repositories.