### PR TITLE
link-check: do not remove tmp file at the end

### DIFF
--- a/link-check/steps.sh
+++ b/link-check/steps.sh
@@ -66,5 +66,3 @@ fi
          ${INPUT_VERBOSE:+-v} \
          ${INPUT_DOC_ROOT:+--root-dir "${INPUT_DOC_ROOT}"}) \
   && echo "No broken links!"
-
-rm -f "${FILES}"


### PR DESCRIPTION
The `rm -f` was masking the exit code of the link check itself, which means that a failure there would not fail the corresponding GitHub check. Instead of capturing and passing out the exit code, remove the `rm -f` clean-up at the end, because the container is being discarded anyway.