### PR TITLE
bashisms: remove link to versioned tar file

### DIFF
--- a/bashisms/README.md
+++ b/bashisms/README.md
@@ -38,7 +38,8 @@ jobs:
 
 ### Maintenance
 
-The `checkbashism` script in `../scripts` is directly extracted from
-<https://deb.debian.org/debian/pool/main/d/devscripts/devscripts_2.25.2.tar.xz>.
+The `checkbashism` script in `../scripts` is directly extracted from the
+`devscripts_2.XXX.tar.xz` file in
+<https://deb.debian.org/debian/pool/main/d/devscripts/>.
 Installing it via `apt-get` takes forever, because the rest of the devscripts
 has lots of dependencies.


### PR DESCRIPTION
There are too many updates to the tar file without changes to the bashisms checker script to go and check every time `devscripts` gets updated and the link checker raises a failure.

Point to the directory instead, so that the link checker no longer raises an alarm for version updates.