### PR TITLE
github: pin gitlint in pr workflow to ubuntu 22.04

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   gitlint:
     name: Gitlint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: seL4/ci-actions/gitlint@master
       with:


### PR DESCRIPTION
Running on Ubuntu 24.04 sometimes (not always) produces installation failure in the python setup step. Until that is sorted out, run the workflow only on Ubuntu 22.04.