### PR TITLE
fix gitlint & style lints

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,7 @@ jobs:
 
   style:
     name: Style
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: seL4/ci-actions/style@master
       with:

--- a/scripts/install-python.sh
+++ b/scripts/install-python.sh
@@ -7,6 +7,8 @@
 # Installs python 3.10; assumes GitHub's ubuntu-latest
 
 echo "Installing python 3.10"
+# for python 3.10 for newer ubuntu distributions
+sudo add-apt-repository ppa:deadsnakes/ppa
 sudo apt-get install -qq python3.10 > /dev/null
 sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1
 sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1

--- a/scripts/install-python.sh
+++ b/scripts/install-python.sh
@@ -11,4 +11,9 @@ sudo apt-get install -qq python3.10 > /dev/null
 sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1
 sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
 python3 --version
-pip3 install -q --upgrade pip setuptools==70.0.0 launchpadlib wheel
+
+# setuptools and wheel versions must be matched to working releases
+# we need an old version of setuptools (see PR seL4/ci-actions#381)
+# and newer versions of wheel removes the bdist_wheel implementation
+# that setuptools used to use, but no longer does in newer versions.
+pip3 install -q --upgrade pip setuptools==70.0.0 wheel==0.45.1 launchpadlib


### PR DESCRIPTION
Note: CI is expected to fail because it forces the GHA to use the version of the `master` branch. Which is horribly confusing.