### PR TITLE
license-check: bump reuse version to 5.0.2

### DIFF
--- a/license-check/steps.sh
+++ b/license-check/steps.sh
@@ -10,7 +10,7 @@ echo "::group::Setting up"
 install-python.sh
 
 echo "Installing reuse tool"
-pip3 install -q reuse==3.0.2
+pip3 install -q reuse==5.0.2
 
 checkout.sh
 echo "::endgroup::"


### PR DESCRIPTION
Allows replacing dep5 with REUSE.toml, which is more usable and has saner pattern matching.