### PR TITLE
sel4bench-web: generate json instead of html

### DIFF
--- a/sel4bench/build.py
+++ b/sel4bench/build.py
@@ -219,7 +219,6 @@ def gen_json(runs: List[Run], yml, file_name: str):
         ('ISA', 'isa'),
         ('Mode', 'mode'),
         ('Core/SoC/Board', 'name'),
-        ('Clock', 'clock'),
         ('Compiler', 'compiler'),
         ('Build command', 'build_command'),
     ]

--- a/sel4bench/builds.yml
+++ b/sel4bench/builds.yml
@@ -60,7 +60,7 @@ boards:
         compiler: gcc GNU 10.2.1
     Skylake:
         soc: i7-6700
-        note: (without meltdown mitigation)
+        note: without meltdown mitigation
         clock: 3.4 GHz
         compiler: gcc GNU 10.2.1
     Jetson:


### PR DESCRIPTION
Since the site is running on Jekyll it makes more sense to generate the page there directly and just provide the data as json input.

After the redesign, the new site is going to expect json input of for produce here.