### PR TITLE
link-checker: token for GitHub rate limiting

### DIFF
--- a/link-check/action.yml
+++ b/link-check/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: 'Maximum number of concurrent requests'
     required: false
   token:
-    description: 'GitHub token for read access to repository'
+    description: 'GitHub token for read access to repository and rate limit'
     required: false
   verbose:
     description: 'Print more information if set (default unset)'

--- a/link-check/steps.sh
+++ b/link-check/steps.sh
@@ -49,7 +49,7 @@ if [ -s "${FILES}" ]; then
   echo "Checking links in the following files:"
   echo "::group::Files"
   cat "${FILES}"
-  echo "::group::Files"
+  echo "::endgroup::"
 else
   echo "No files to check"
   rm -f "${FILES}"

--- a/link-check/steps.sh
+++ b/link-check/steps.sh
@@ -59,6 +59,7 @@ fi
 (set -x; \
   cat "${FILES}" | tr '\n' '\000' | \
   xargs -0 lychee -n \
+         ${INPUT_TOKEN:+--github-token "${INPUT_TOKEN}"} \
          ${INPUT_EXCLUDE:+--exclude-path "${INPUT_EXCLUDE}"} \
          ${INPUT_TIMEOUT:+-t "${INPUT_TIMEOUT}"} \
          ${INPUT_NUM_REQUESTS:+--max-concurrency "${INPUT_NUM_REQUESTS}"} \


### PR DESCRIPTION
Pass the option GitHub token argument through to to the link checker to get reduced rate limiting for links on GitHub.
