### PR TITLE
platforms: enable hardware test for imx93

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -171,7 +171,7 @@ platforms:
     aarch_hyp: [64]
     platform: imx93
     march: armv8a
-    no_hw_test: true
+    req: imx93a
 
   OMAP3:
     arch: arm


### PR DESCRIPTION
The board `imx93a` in now available in the machine queue.