### PR TITLE
imx93: configure correct number of cores

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -172,6 +172,10 @@ platforms:
     platform: imx93
     march: armv8a
     req: imx93a
+    settings:
+      # override the default of 4 for sel4test; ignored in non-SMP builds
+      # if the platform is enabled for other apps this may need manual override
+      NUM_NODES=2
 
   OMAP3:
     arch: arm


### PR DESCRIPTION
sel4test automatically configures a default of 4 cores for SMP tests, but the imx93 only has 2. Most other projects/tests do not use the NUM_NODES setting and will ignore it.
