### PR TITLE
platforms: temporarily disable build for CHESHIRE

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -36,6 +36,7 @@ platforms:
     platform: cheshire
     march: rv64imac
     no_hw_test: true
+    no_hw_build: true
 
   SPIKE32:
     arch: riscv


### PR DESCRIPTION
Until sel4test builds properly.

It turns out that sel4bench builds fine, but sel4test is still complaining about a missing ltimer: https://github.com/seL4/seL4/actions/runs/15272147844/job/42950040656