### PR TITLE
update Isabelle mirror for Ubuntu 24.04

### DIFF
--- a/.github/workflows/isabelle-mirror.yml
+++ b/.github/workflows/isabelle-mirror.yml
@@ -15,7 +15,7 @@ jobs:
   isabelle-mirror:
     name: 'Isabelle Mirror'
     if: ${{ github.repository_owner == 'seL4' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       ISA_MIRROR_TOKEN: ${{ secrets.ISA_MIRROR_TOKEN }}
     steps:

--- a/isabelle-mirror/steps.sh
+++ b/isabelle-mirror/steps.sh
@@ -8,9 +8,25 @@ set -e
 
 echo "::group::Setting up"
 echo "Installing python 2.7"
-sudo apt update
-sudo apt-get install -qq python2-dev > /dev/null
-sudo update-alternatives --install /usr/bin/python python /usr/bin/python2 1
+
+echo "  > Installing python build dependencies"
+sudo apt-get update
+sudo apt-get install -qq make build-essential libssl-dev zlib1g-dev \
+                         libbz2-dev libreadline-dev libsqlite3-dev curl git \
+                         libncursesw5-dev xz-utils tk-dev libxml2-dev \
+                         libxmlsec1-dev libffi-dev liblzma-dev
+
+echo "  > Installing pyenv"
+git clone -b v2.6.1 --depth 1 https://github.com/pyenv/pyenv.git ~/.pyenv
+export PYENV_ROOT="$HOME/.pyenv"
+[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init - bash)"
+
+echo "  > Installing python 2.7"
+pyenv install 2.7
+pyenv global 2.7
+
+echo "  > Versions"
 python --version
 hg --version
 


### PR DESCRIPTION
The previously pinned Ubuntu version (20.04) is now out of service and no longer available on GitHub runners. We used it, because it still provided packages for python 2.7, which the ancient Isabelle mirror scripts need.

Attempting to upgrade the mirror scripts themselves has in the past led to incompatible hg/git conversions (incompatible git trees), so instead this PR jumps through some hoops to install python 2.7 on Ubuntu 24.04 instead.

I've tested on my own fork, and the python part seems to work fine. It looks like the Isabelle repo is currently (unrelatedly) producing 503 on https. If that is permanent, we'll need to figure out something else.
