### PR TITLE
pin junitparser to v3; print junit exceptions

### DIFF
--- a/camkes-test/Dockerfile
+++ b/camkes-test/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
-RUN pip3 install junitparser PyGithub
+RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG ACTION
 ARG SCRIPTS

--- a/camkes-vm/Dockerfile
+++ b/camkes-vm/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
-RUN pip3 install junitparser PyGithub
+RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG ACTION
 ARG SCRIPTS

--- a/cparser-run/Dockerfile
+++ b/cparser-run/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
-RUN pip3 install junitparser PyGithub
+RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG ACTION
 ARG SCRIPTS

--- a/rump-hello/Dockerfile
+++ b/rump-hello/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
-RUN pip3 install junitparser PyGithub
+RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG ACTION
 ARG SCRIPTS

--- a/scripts/hw-steps.sh
+++ b/scripts/hw-steps.sh
@@ -25,7 +25,7 @@ export ACTION_DIR="${SCRIPTS}/.."
 
 # python env
 sudo apt-get install -y --no-install-recommends libffi-dev
-pip3 install --user junitparser==3.* sel4-deps
+pip3 install --user "junitparser==3.*" sel4-deps
 export PYTHONPATH="${ACTION_DIR}/seL4-platforms"
 echo "::endgroup::"
 

--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -641,8 +641,9 @@ def run_build_script(manifest_dir: str,
             except IOError:
                 printc(ANSI_RED, f"Error reading {junit_file}")
                 result = FAILURE
-            except:
+            except Exception as e:
                 printc(ANSI_RED, f"Error parsing {junit_file}")
+                print("Exception: " + e)
                 result = FAILURE
 
         if result == REPEAT and tries_left > 0:

--- a/sel4bench-web/steps.sh
+++ b/sel4bench-web/steps.sh
@@ -10,7 +10,7 @@ export ACTION_DIR="${SCRIPTS}/.."
 
 # python env
 sudo apt-get install -y --no-install-recommends libffi-dev
-pip3 install --user junitparser sel4-deps
+pip3 install --user "junitparser==3.*" sel4-deps
 export PYTHONPATH="${ACTION_DIR}/seL4-platforms"
 echo "::endgroup::"
 

--- a/sel4bench/Dockerfile
+++ b/sel4bench/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
-RUN pip3 install junitparser PyGithub
+RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG SCRIPTS
 ARG ACTION

--- a/sel4test-hw-matrix/steps.sh
+++ b/sel4test-hw-matrix/steps.sh
@@ -12,7 +12,7 @@ export ACTION_DIR="${SCRIPTS}/.."
 
 # python env
 sudo apt-get install -y --no-install-recommends libffi-dev
-pip3 install --user junitparser sel4-deps
+pip3 install --user "junitparser==3.*" sel4-deps
 export PYTHONPATH="${ACTION_DIR}/seL4-platforms"
 echo "::endgroup::"
 

--- a/sel4test-hw/Dockerfile
+++ b/sel4test-hw/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
-RUN pip3 install junitparser PyGithub
+RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG SCRIPTS
 ARG ACTION

--- a/sel4test-sim/Dockerfile
+++ b/sel4test-sim/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
-RUN pip3 install junitparser PyGithub
+RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG SCRIPTS
 ARG ACTION

--- a/tutorials/Dockerfile
+++ b/tutorials/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
-RUN pip3 install junitparser PyGithub
+RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG ACTION
 ARG SCRIPTS

--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
 RUN gem install bundler:2.1.2
-RUN pip3 install junitparser PyGithub
+RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG ACTION
 ARG SCRIPTS


### PR DESCRIPTION
junitparser has released v4, with API breaking changes that result in an exception. Pin to version 3 to keep things working, and print any junitparser exceptions to make debugging this easier in the future.