### PR TITLE
platforms.yml: fix HiFive P550

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -95,7 +95,7 @@ platforms:
     modes: [64]
     smp: [64]
     platform: hifive-p550
-    march: rv64imacfd
+    march: rv64imac
     req: [p550a]
 
   SABRE:


### PR DESCRIPTION
Has to be `rv64imac` for now until we merge some other patches.