### PR TITLE
platforms: second imx93 board available

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -187,7 +187,7 @@ platforms:
     aarch_hyp: [64]
     platform: imx93
     march: armv8a
-    req: imx93a
+    req: [imx93a,imx93b]
     settings:
       # override the default of 4 for sel4test; ignored in non-SMP builds
       # if the platform is enabled for other apps this may need manual override


### PR DESCRIPTION
As `imx93b`