### PR TITLE
platforms.yml: disable HiFive P550 SMP runs for now

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -92,7 +92,6 @@ platforms:
   HIFIVE_P550:
     arch: riscv
     modes: [64]
-    smp: [64]
     platform: hifive-p550
     march: rv64imac
     req: [p550a]


### PR DESCRIPTION
When doing the initial port of the P550 to seL4, I saw failures when booting SMP but they were fixed after some improvements were made to the locking code by Indan. However, I was testing only in GCC and it looks like Clang has failures that must still be investigated.

See [1] for details.

[1]: https://github.com/seL4/seL4/actions/runs/16181893559/job/45764557154