### PR TITLE
platforms.yml: re-enable SMP on HiFive P550

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -92,6 +92,7 @@ platforms:
   HIFIVE_P550:
     arch: riscv
     modes: [64]
+    smp: [64]
     platform: hifive-p550
     march: rv64imac
     req: [p550a]


### PR DESCRIPTION
PR https://github.com/seL4/seL4_tools/pull/232 should have fixed SMP booting with the elfloader. I'm not sure if the PR is part of the manifest yet, we should not merge this until it is.