### PR TITLE
sel4test-hw: increase verification skip scope

### DIFF
--- a/sel4test-hw/build.py
+++ b/sel4test-hw/build.py
@@ -65,7 +65,8 @@ def hw_run(manifest_dir: str, build: Build):
 def verification_equals_release(build: Build) -> bool:
     """Return whether in this build release and verification settings are equivalent."""
 
-    return build.get_platform().arch == 'riscv'
+    plat = build.get_platform()
+    return plat.arch == 'riscv' or plat.arch == 'arm'
 
 
 def build_filter(build: Build) -> bool:


### PR DESCRIPTION
After corresponding PRs in seL4 and seL4test, increase the scope of skipping verification builds (and checking for config equivalences with release instead).

Needs to wait for https://github.com/seL4/sel4test/pull/154 to be merged and deployed before we can merge here.