### PR TITLE
sel4test-hw: fix verification+smp check

### DIFF
--- a/sel4test-hw/build.py
+++ b/sel4test-hw/build.py
@@ -53,7 +53,7 @@ def hw_run(manifest_dir: str, build: Build):
         print(f"Build {build.name} disabled, skipping.")
         return SKIP
 
-    if build.is_verification() and build.is_smp:
+    if build.is_verification() and build.is_smp():
         print(f"Build {build.name} is verification+SMP, skipping.")
         return SKIP
 


### PR DESCRIPTION
The check was using `build.is_smp` instead of `build.is_smp()` and was therefore always true..