### PR TITLE
preprocess: provide a base_branch option

### DIFF
--- a/preprocess/action.yml
+++ b/preprocess/action.yml
@@ -18,6 +18,11 @@ inputs:
     description: 'Additional features to include. Empty ("") or "MCS".'
     required: false
 
+  base_ref:
+    description: |
+      seL4 base ref to compare against instead of the verification manifest hash.
+    required: false
+
   action_name:
     description: 'internal -- do not use'
     required: false

--- a/preprocess/steps.sh
+++ b/preprocess/steps.sh
@@ -19,7 +19,21 @@ checkout-manifest.sh
 
 REPOS="$(pwd)"
 SEL4_REPO="${REPOS}/seL4"
-MANIFEST_REV=$(git -C ${SEL4_REPO} rev-parse HEAD)
+
+REMOTE=$(git -C ${SEL4_REPO} remote)
+if [ "$(echo "${REMOTE}" | wc -l)" -ne 1 ]; then
+  echo "::error::Expected exactly one remote, got: ${REMOTE}"
+  exit 1
+fi
+
+if [ -n "${INPUT_BASE_REF}" ]
+then
+  # Use the tip of the specified base branch instead of the manifest hash
+  git -C ${SEL4_REPO} fetch -q --depth 1 "${REMOTE}" "${INPUT_BASE_REF}"
+  git -C ${SEL4_REPO} checkout -q FETCH_HEAD
+fi
+
+BASE_REV=$(git -C ${SEL4_REPO} rev-parse HEAD)
 
 cd "${SEL4_REPO}"
 export BRANCH_NAME="github-ci-work/pr-branch"
@@ -29,7 +43,7 @@ fetch-branch.sh
 TEST_REF=$(git rev-parse HEAD)
 
 # restore previous state
-git checkout -q ${MANIFEST_REV}
+git checkout -q ${BASE_REV}
 cd - > /dev/null
 
 repo-util hashes
@@ -39,7 +53,7 @@ cp -r /c-parser "${REPOS}/l4v/tools/"
 echo "::endgroup::"
 
 # one test for the default L4V_ARCH/L4V_FEATURES combination
-test_munge.sh -ac -p "${REPOS}" $MANIFEST_REV $TEST_REF
+test_munge.sh -ac -p "${REPOS}" $BASE_REV $TEST_REF
 
 # then all platform combinations if any exist
 
@@ -55,5 +69,5 @@ cd - > /dev/null
 for CONFIG in ${CONFIGS}; do
   L4V_PLAT=${CONFIG##${L4V_ARCH}_${FEAT}}
   export L4V_PLAT=${L4V_PLAT%_verified.cmake}
-  test_munge.sh -ac -p "${REPOS}" $MANIFEST_REV $TEST_REF
+  test_munge.sh -ac -p "${REPOS}" $BASE_REV $TEST_REF
 done


### PR DESCRIPTION
Provide the option for checking against a specific base branch instead of the revision in the verification manifest.

Useful for pull-request checking when the base branch has moved on over the verification manifest.

This is the first half of implementing https://github.com/seL4/seL4/issues/1299. When this is merged, we still need to update the corresponding workflow file in the seL4 repo.