### PR TITLE
trivial: perform error checking

### DIFF
--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -46,6 +46,11 @@ if [ -z ${IP} ]; then exit 1; fi
 echo "Waiting for sshd to come up"
 until nc -w5 -z ${IP} 22; do echo "."; sleep 3; done
 
+if [ -z "${AWS_SSH}" ]; then
+  echo "No 'AWS_SSH' key provided" >&2
+  exit 1
+fi
+
 eval $(ssh-agent)
 ssh-add -q - <<< "${AWS_SSH}"
 

--- a/l4v-deploy/steps.sh
+++ b/l4v-deploy/steps.sh
@@ -16,6 +16,11 @@ PATH=~/bin:"${SCRIPTS}/../l4v-deploy":$PATH
 
 pip3 install --user lxml
 
+if [ -z "${GH_SSH}" ]; then
+  echo "No 'GH_SSH' key provided" >&2
+  exit 1
+fi
+
 eval $(ssh-agent)
 ssh-add -q - <<< "${GH_SSH}"
 echo "::endgroup::"

--- a/manifest-deploy/steps.sh
+++ b/manifest-deploy/steps.sh
@@ -15,6 +15,11 @@ chmod a+x ~/bin/repo
 
 PATH=~/bin:"${GITHUB_WORKSPACE}/seL4_release":$PATH
 
+if [ -z "${GH_SSH}" ]; then
+  echo "No 'GH_SSH' key provided" >&2
+  exit 1
+fi
+
 echo "Setting up ssh"
 eval $(ssh-agent)
 ssh-add -q - <<< "${GH_SSH}"

--- a/scripts/fetch-branch.sh
+++ b/scripts/fetch-branch.sh
@@ -7,6 +7,8 @@
 # Fetches the branch in ${GITHUB_REF} into a repo manifest checkout.
 # Does nothing if INPUT_XML is set, because that means we have already done this.
 
+set -e
+
 if [ -z "${INPUT_XML}" ]
 then
 

--- a/scripts/fetch-branches.sh
+++ b/scripts/fetch-branches.sh
@@ -8,6 +8,8 @@
 # Skips branch fetching if explicit input manifest XML is present.
 # Always print repo summary. Needs a repo checkout.
 
+set -e
+
 if [ -z "${INPUT_XML}" ]
 then
   cd $(repo-util path ${GITHUB_REPOSITORY})

--- a/scripts/setup-hw-ssh.sh
+++ b/scripts/setup-hw-ssh.sh
@@ -35,5 +35,10 @@ Host tftp.keg.cse.unsw.edu.au
 
 EOF
 
+if [ -z "${HW_SSH}" ]; then
+  echo "No 'HW_SSH' key provided" >&2
+  exit 1
+fi
+
 eval $(ssh-agent)
 ssh-add -q - <<< "${HW_SSH}"


### PR DESCRIPTION
Check that SSH keys as environment variables are set, and use `set -e` in a few scripts to check return codes.

Non-functional change.

Splitting out from https://github.com/au-ts/seL4-ci-actions/pull/1.