### PR TITLE
manifest deploy/checkout: support non-seL4 repos

### DIFF
--- a/manifest-deploy/action.yml
+++ b/manifest-deploy/action.yml
@@ -12,8 +12,18 @@ inputs:
   xml:
     description: manifest to deploy in xml
     required: true
+  manifest:
+    description: |
+      the manifest xml file name to checkout from, if xml not specified.
+      NOT used for the deploy, which uses default.xml always
+    default: master.xml
+    required: false
   manifest_repo:
     description: the manifest repository to deploy to
+    required: false
+  manifest_branch:
+    description: Manifest repo branch
+    default: master
     required: false
   action_name:
     description: 'internal -- do not use'

--- a/manifest-deploy/steps.sh
+++ b/manifest-deploy/steps.sh
@@ -30,12 +30,19 @@ sudo apt-get install -qq doxygen
 echo "::endgroup::"
 
 echo "::group::Repo checkout"
-export MANIFEST_URL="ssh://git@github.com/seL4/${INPUT_MANIFEST_REPO}.git"
-export REPO_MANIFEST=master.xml
+if echo "$INPUT_MANIFEST_REPO" | grep -q "/" 2>/dev/null; then
+  export MANIFEST_URL="ssh://git@github.com/${INPUT_MANIFEST_REPO}.git"
+else
+  export MANIFEST_URL="ssh://git@github.com/seL4/${INPUT_MANIFEST_REPO}.git"
+fi
+export REPO_BRANCH="${INPUT_MANIFEST_BRANCH}"
+export REPO_MANIFEST="${INPUT_MANIFEST}"
 export REPO_DEPTH=0
 checkout-manifest.sh
 repo-util hashes
 echo "::endgroup::"
+# releaseit always writes to 'default.xml'
+unset REPO_MANIFEST
 
 echo "::group::Deploy"
 releaseit nightly --release

--- a/repo-checkout/action.yml
+++ b/repo-checkout/action.yml
@@ -9,11 +9,15 @@ author: Gerwin Klein <gerwin.klein@proofcraft.systems>
 
 inputs:
   manifest_repo:
-    description: Manifest repostory (e.g. 'sel4test-manifest', 'sel4bench-manifest')
+    description: Manifest repository (e.g. 'sel4test-manifest', 'sel4bench-manifest')
     required: true
   manifest:
     description: Manifest file
     default: master.xml
+    required: false
+  manifest_branch:
+    description: Manifest repo branch
+    default: master
     required: false
   sha:
     description: |

--- a/repo-checkout/steps.sh
+++ b/repo-checkout/steps.sh
@@ -20,8 +20,13 @@ echo "::endgroup::"
 
 echo "::group::Repo checkout"
 
+if echo "$INPUT_MANIFEST_REPO" | grep -q "/" 2>/dev/null; then
+  export MANIFEST_URL="https://github.com/${INPUT_MANIFEST_REPO}"
+else
+  export MANIFEST_URL="https://github.com/seL4/${INPUT_MANIFEST_REPO}"
+fi
 export REPO_MANIFEST="${INPUT_MANIFEST}"
-export MANIFEST_URL="https://github.com/seL4/${INPUT_MANIFEST_REPO}"
+export REPO_BRANCH="${INPUT_MANIFEST_BRANCH}"
 checkout-manifest.sh
 
 fetch-branches.sh


### PR DESCRIPTION
Also support branches other than 'master', to use names such as 'main'.

You can specify e.g. `manifest_repo: au-ts/microkit-manifest`.

Split out from https://github.com/au-ts/seL4-ci-actions/pull/1. Not strictly necessary to be merged in here, but useful for developing on a private fork.