### PR TITLE
checkout: sync --tags too

### DIFF
--- a/scripts/checkout-manifest.sh
+++ b/scripts/checkout-manifest.sh
@@ -44,4 +44,4 @@ then
   $REPO init ${DEPTH} -m "${TEST_XML}"
 fi
 
-$REPO sync -j 4
+$REPO sync -j 4 --tags


### PR DESCRIPTION
Microkit uses the tags for building the SDK version.

Part of https://github.com/au-ts/seL4-ci-actions/pull/1. 

I don't think it is worth adding a configuration option to optionally sync tags, but I might be wrong.