### PR TITLE
Avoid storing binaries in $HOME for local runners

### DIFF
--- a/l4v-deploy/steps.sh
+++ b/l4v-deploy/steps.sh
@@ -8,11 +8,13 @@
 set -e
 
 echo "::group::Setting up"
-mkdir -p ~/bin
-curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
-chmod a+x ~/bin/repo
 
-PATH=~/bin:"${SCRIPTS}/../l4v-deploy":$PATH
+BINDIR="${RUNNER_TEMP}/bin"
+mkdir -p "${BINDIR}"
+curl https://storage.googleapis.com/git-repo-downloads/repo > "${BINDIR}/repo"
+chmod a+x "${BINDIR}/repo"
+
+PATH="${BINDIR}":"${SCRIPTS}/../l4v-deploy":$PATH
 
 pip3 install --user lxml
 

--- a/manifest-deploy/steps.sh
+++ b/manifest-deploy/steps.sh
@@ -8,12 +8,14 @@
 set -e
 
 echo "::group::Setting up"
-echo "Installing 'repo'"
-mkdir -p ~/bin
-curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
-chmod a+x ~/bin/repo
 
-PATH=~/bin:"${GITHUB_WORKSPACE}/seL4_release":$PATH
+echo "Installing 'repo'"
+BINDIR="${RUNNER_TEMP}/bin"
+mkdir -p "${BINDIR}"
+curl https://storage.googleapis.com/git-repo-downloads/repo > "${BINDIR}/repo"
+chmod a+x "${BINDIR}/repo"
+
+PATH="${BINDIR}":"${GITHUB_WORKSPACE}/seL4_release":$PATH
 
 if [ -z "${GH_SSH}" ]; then
   echo "No 'GH_SSH' key provided" >&2

--- a/repo-checkout/steps.sh
+++ b/repo-checkout/steps.sh
@@ -9,10 +9,12 @@ set -e
 
 echo "::group::Setting up"
 
-mkdir -p ~/bin
-curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
-chmod a+x ~/bin/repo
-PATH=~/bin:$PATH
+BINDIR="${RUNNER_TEMP}/bin"
+mkdir -p "${BINDIR}"
+curl https://storage.googleapis.com/git-repo-downloads/repo > "${BINDIR}/repo"
+chmod a+x "${BINDIR}/repo"
+
+PATH="${BINDIR}":$PATH
 
 pip3 install -U PyGithub
 


### PR DESCRIPTION
If we use a local runner to build, the builds are not sandboxed. This is mostly fine for this use, but let's avoid installing files in global folders. Instead namespace it under $GITHUB_WORKSPACE which is unique to a build.

Part of https://github.com/au-ts/seL4-ci-actions/pull/1, but not necessary to merge.
Just a nicety.