### PR TITLE
Dockerfile: set up a virtual environment

### DIFF
--- a/camkes-test/Dockerfile
+++ b/camkes-test/Dockerfile
@@ -12,10 +12,14 @@ FROM trustworthysystems/camkes-cakeml-rust:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       libffi-dev \
+       libffi-dev python3-venv \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG ACTION

--- a/camkes-vm/Dockerfile
+++ b/camkes-vm/Dockerfile
@@ -12,10 +12,14 @@ FROM trustworthysystems/camkes:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       libffi-dev \
+       libffi-dev python3-venv \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG ACTION

--- a/cparser-run/Dockerfile
+++ b/cparser-run/Dockerfile
@@ -14,10 +14,14 @@ COPY --from=sel4/cparser-builder /c-parser /c-parser
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       libffi-dev \
+       libffi-dev python3-venv \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG ACTION

--- a/rump-hello/Dockerfile
+++ b/rump-hello/Dockerfile
@@ -12,10 +12,14 @@ FROM trustworthysystems/camkes:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       libffi-dev \
+       libffi-dev python3-venv \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG ACTION

--- a/sel4bench/Dockerfile
+++ b/sel4bench/Dockerfile
@@ -12,10 +12,14 @@ FROM trustworthysystems/sel4:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       libffi-dev \
+       libffi-dev python3-venv \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG SCRIPTS

--- a/sel4test-hw/Dockerfile
+++ b/sel4test-hw/Dockerfile
@@ -12,10 +12,14 @@ FROM trustworthysystems/sel4:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       libffi-dev \
+       libffi-dev python3-venv \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG SCRIPTS

--- a/sel4test-sim/Dockerfile
+++ b/sel4test-sim/Dockerfile
@@ -12,10 +12,14 @@ FROM trustworthysystems/sel4:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       libffi-dev \
+       libffi-dev python3-venv \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG SCRIPTS

--- a/tutorials/Dockerfile
+++ b/tutorials/Dockerfile
@@ -12,10 +12,14 @@ FROM trustworthysystems/camkes:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       libffi-dev \
+       libffi-dev python3-venv \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG ACTION

--- a/webserver/Dockerfile
+++ b/webserver/Dockerfile
@@ -12,11 +12,15 @@ FROM trustworthysystems/camkes:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       rubygems ruby-dev bundler doxygen \
+       rubygems ruby-dev bundler doxygen python3-venv \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
 RUN gem install bundler:2.1.2
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip3 install "junitparser==3.*" PyGithub
 
 ARG ACTION


### PR DESCRIPTION
The Docker deploy actions were failing due to break-system-packages python 'feature' that exists in newer debians.

Note: this fixes the docker builds. I have yet to fix the other uses of `pip3 install`, which I also need to make operate in a virtual environment now.