### PR TITLE
Support Microkit HW CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,5 @@
 
 # Request review from Gerwin by default
 *   @lsf37
+# .. except for Microkit
+/microkit-*/    @midnightveil

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ The following GitHub actions are available:
 - [Link Check](link-check/): checks links in `.md` and `.html` files
 - [Manifest Deploy](manifest-deploy/): deploys default.xml manifests after successful tests
 - [m-arch of Platform](march-of-platform/): outputs the `march` of a given platform
+- [microkit Hardware Builds](microkit-hw-build/): microkit image builds
+- [microkit Hardware Runs](microkit-hw-run/): microkit hardware runs
+- [microkit Hardware Run Matrix](microkit-hw-matrix/): matrix for microkit hardware runs
 - [Preprocess](preprocess/): run AST diff on preprocessed source for verified configurations
 - [Repo Checkout](repo-checkout/): checks out a `repo` collection
 - [RumpRun](rump-hello/): rumprun hello-world simulation test

--- a/microkit-hw-build/README.md
+++ b/microkit-hw-build/README.md
@@ -1,0 +1,47 @@
+<!--
+     Copyright 2026, UNSW
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Microkit Hardware Builds
+
+This action builds test examples for the [microkit] hardware test platforms.
+
+Refer to the [microkit-hw-run README] for more information.
+
+[microkit]: https://docs.sel4.systems/projects/microkit/
+[microkit-hw-run README]: ../microkit-hw-run/README.md
+
+## Content
+
+The entry point is the script [steps.sh].
+
+The main test driver [build.py] in this directory is shared with (a symlink to)
+the [microkit-hw-run build.py] to make sure the same filters are applied.
+
+[steps.sh]: ./steps.sh
+[build.py]: ./build.py
+[microkit-hw-run build.py]: ../microkit-hw-run/build.py
+
+## Arguments
+
+To add or modify platform options, create a PR to the [Microkit repository].
+
+[Microkit repository]: https://github.com/seL4/microkit
+
+To filter the build variants defined there for a specific run, use one or more
+of the following action inputs:
+
+- `board`: comma separated list of Microkit board names to filter, e.g. `maaxboard,star64`.
+- `config`: comma separated list of Microkit config names, e.g. `debug,release`.
+- `march`: comma separated list of Microkit board architectures, e.g. `aarch64,riscv64,x86_64`.
+
+## Environment
+
+The action expects the following environment variables to be set:
+
+- `TEST_CASES`: the JSON output from the [microkit-hw-matrix] 'test_cases' GitHub output.
+- `MICROKIT_SDK`: the path to the prebuild Microkit SDK.
+
+[microkit-hw-matrix]: ../microkit-hw-matrix/README.md

--- a/microkit-hw-build/action.yml
+++ b/microkit-hw-build/action.yml
@@ -1,0 +1,31 @@
+# Copyright 2021, Proofcraft Pty Ltd
+# Copyright 2026, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: 'microkit/Hardware Builds'
+description: |
+  Does microkit hw builds.
+author: Julia Vassiliki <julia.vassiliki@unsw.edu.au>
+
+inputs:
+  board:
+    description: Comma separated list of microkit boards (MICROKIT_BOARD) to run the test for.
+    required: true
+  config:
+    description: Comma separated list of microkit configs (MICROKIT_CONFIG) to run the test for.
+    required: false
+  march:
+    description: Comma separated list of platform marches (from platforms.yml) to run the test for.
+    required: false
+  index:
+    description: job index in matrix build
+    required: true
+  action_name:
+    description: 'internal -- do not use'
+    required: false
+    default: 'microkit-hw-build'
+
+runs:
+  using: 'node24'
+  main: '../js/index.js'

--- a/microkit-hw-build/action.yml
+++ b/microkit-hw-build/action.yml
@@ -5,18 +5,18 @@
 
 name: 'microkit/Hardware Builds'
 description: |
-  Does microkit hw builds.
+  Builds Microkit examples for all hardware test platforms.
 author: Julia Vassiliki <julia.vassiliki@unsw.edu.au>
 
 inputs:
   board:
-    description: Comma separated list of microkit boards (MICROKIT_BOARD) to run the test for.
+    description: Comma separated list of microkit boards (MICROKIT_BOARD) to build the test for.
     required: true
   config:
-    description: Comma separated list of microkit configs (MICROKIT_CONFIG) to run the test for.
+    description: Comma separated list of microkit configs (MICROKIT_CONFIG) to build the test for.
     required: false
   march:
-    description: Comma separated list of platform marches (from platforms.yml) to run the test for.
+    description: Comma separated list of microkit architectures to build the test for.
     required: false
   index:
     description: job index in matrix build

--- a/microkit-hw-build/build.py
+++ b/microkit-hw-build/build.py
@@ -1,0 +1,1 @@
+../microkit-hw-run/build.py

--- a/microkit-hw-build/steps.sh
+++ b/microkit-hw-build/steps.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# generic steps to invoke hardware builds on the machine queue
+# expects a standard `build.py --hw` invocation to work in directory INPUT_ACTION_NAME
+
+set -e
+
+echo "::group::Setting up"
+export ACTION_DIR="${SCRIPTS}/.."
+export PYTHONPATH="${ACTION_DIR}/seL4-platforms"
+
+# python env
+sudo apt-get install -y --no-install-recommends libffi-dev
+if [ -z "${VIRTUAL_ENV}" ]; then
+  python3 -m venv "${GITHUB_WORKSPACE}/venv"
+  . "${GITHUB_WORKSPACE}/venv/bin/activate"
+fi
+pip3 install "junitparser==3.*" sel4-deps
+
+echo "::endgroup::"
+
+# start builds
+python3 "${ACTION_DIR}/${INPUT_ACTION_NAME}/build.py"

--- a/microkit-hw-build/steps.sh
+++ b/microkit-hw-build/steps.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Copyright 2026, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# generic steps to invoke hardware builds on the machine queue
+# expects a standard `build.py --hw` invocation to work in directory INPUT_ACTION_NAME
+
+set -e
+
+echo "::group::Setting up"
+export ACTION_DIR="${SCRIPTS}/.."
+export PYTHONPATH="${ACTION_DIR}/seL4-platforms"
+
+# python env
+sudo apt-get install -y --no-install-recommends libffi-dev
+. ${SCRIPTS}/setup-python-venv.sh
+pip3 install "junitparser==3.*" sel4-deps
+
+echo "::endgroup::"
+
+# start builds
+python3 "${ACTION_DIR}/${INPUT_ACTION_NAME}/build.py"

--- a/microkit-hw-matrix/README.md
+++ b/microkit-hw-matrix/README.md
@@ -1,0 +1,31 @@
+<!--
+     Copyright 2026, UNSW
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Microkit Hardware Run Matrix
+
+This action generates a GitHub build matrix for the [microkit-hw-run] action from
+the information available in the [Microkit SDK build system]. For more details,
+see the [microkit-hw-run README].
+
+[microkit-hw-run]: ../microkit-hw-run/README.md
+[Microkit SDK build system]: https://github.com/seL4/microkit/blob/main/build_sdk.py
+
+## Content
+
+The entry point is the script [steps.sh].
+
+The main test driver [build.py] in this directory is shared with (a symlink to)
+the [microkit-hw-run build.py] to make sure the same filters are applied.
+
+[steps.sh]: ./steps.sh
+[build.py]: ./build.py
+[microkit-hw-run build.py]: ../microkit-hw-run/build.py
+
+## Arguments
+
+This action has no input arguments. It expects the current working directory to
+contain a folder called 'microkit' containing the Microkit source and a folder
+called 'seL4' containing the seL4 kernel source code.

--- a/microkit-hw-matrix/action.yml
+++ b/microkit-hw-matrix/action.yml
@@ -1,0 +1,19 @@
+# Copyright 2021, Proofcraft Pty Ltd
+# Copyright 2026, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: 'microkit/Hardware Matrix'
+description: |
+  Generates hardware build matrix
+author: Julia Vassiliki <julia.vassiliki@unsw.edu.au>
+
+inputs:
+  action_name:
+    description: 'internal -- do not use'
+    required: false
+    default: 'microkit-hw-matrix'
+
+runs:
+  using: 'node24'
+  main: '../js/index.js'

--- a/microkit-hw-matrix/action.yml
+++ b/microkit-hw-matrix/action.yml
@@ -5,7 +5,7 @@
 
 name: 'microkit/Hardware Matrix'
 description: |
-  Generates hardware build matrix
+  Generates hardware build matrix for Microkit.
 author: Julia Vassiliki <julia.vassiliki@unsw.edu.au>
 
 inputs:

--- a/microkit-hw-matrix/build.py
+++ b/microkit-hw-matrix/build.py
@@ -1,0 +1,1 @@
+../microkit-hw-run/build.py

--- a/microkit-hw-matrix/steps.sh
+++ b/microkit-hw-matrix/steps.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# generic steps to invoke hardware builds on the machine queue
+# expects a standard `build.py --hw` invocation to work in directory INPUT_ACTION_NAME
+
+set -e
+
+echo "::group::Setting up"
+export ACTION_DIR="${SCRIPTS}/.."
+export PYTHONPATH="${ACTION_DIR}/seL4-platforms"
+
+# python env
+sudo apt-get install -y --no-install-recommends libffi-dev
+if [ -z "${VIRTUAL_ENV}" ]; then
+  python3 -m venv "${GITHUB_WORKSPACE}/venv"
+  . "${GITHUB_WORKSPACE}/venv/bin/activate"
+fi
+pip3 install "junitparser==3.*" sel4-deps
+
+echo "::endgroup::"
+
+cd microkit
+  python3 build_sdk.py --sel4=../seL4 --matrix=../build_sdk_matrix.json
+
+  export TEST_CASES=$(cat ../build_sdk_matrix.json)
+
+  echo "test_cases=${TEST_CASES}" >> "${GITHUB_OUTPUT}"
+cd -
+
+# exports the gh_output
+python3 "${ACTION_DIR}/${INPUT_ACTION_NAME}/build.py" --matrix

--- a/microkit-hw-matrix/steps.sh
+++ b/microkit-hw-matrix/steps.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright 2026, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# generic steps to invoke hardware builds on the machine queue
+# expects a standard `build.py --hw` invocation to work in directory INPUT_ACTION_NAME
+
+set -e
+
+echo "::group::Setting up"
+export ACTION_DIR="${SCRIPTS}/.."
+export PYTHONPATH="${ACTION_DIR}/seL4-platforms"
+
+# python env
+sudo apt-get install -y --no-install-recommends libffi-dev
+. ${SCRIPTS}/setup-python-venv.sh
+pip3 install "junitparser==3.*" sel4-deps
+
+echo "::endgroup::"
+
+cd microkit
+  python3 build_sdk.py --sel4=../seL4 --matrix=../build_sdk_matrix.json
+
+  export TEST_CASES=$(cat ../build_sdk_matrix.json)
+
+  echo "test_cases=${TEST_CASES}" >> "${GITHUB_OUTPUT}"
+cd -
+
+# exports the gh_output
+python3 "${ACTION_DIR}/${INPUT_ACTION_NAME}/build.py" --matrix

--- a/microkit-hw-run/README.md
+++ b/microkit-hw-run/README.md
@@ -1,0 +1,9 @@
+<!--
+     Copyright 2021, Proofcraft Pty Ltd
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# seL4Test Hardware Test Runs
+
+todo

--- a/microkit-hw-run/README.md
+++ b/microkit-hw-run/README.md
@@ -1,9 +1,66 @@
 <!--
-     Copyright 2021, Proofcraft Pty Ltd
+     Copyright 2026, UNSW
 
      SPDX-License-Identifier: CC-BY-SA-4.0
 -->
 
-# seL4Test Hardware Test Runs
+# Microkit Hardware Test Runs
 
-todo
+This action runs test examples for the [microkit] hardware test platforms.
+The tests can be restricted to specific `board`, `config`, and `march` configurations,
+which we use to create a GitHub actions runner matrix.
+
+The test expects pre-built images produced by the [microkit-hw-build] action,
+and performs the necessary steps to run this image on the [machine queue] at
+UNSW.
+
+The Microkit HW builds & tests are different to many of the other actions in
+this repository; rather than the builds being driven by a 'build.yml' and
+'platforms.yml' file within this repository, it extracts a list of test cases
+/ platforms from the Microkit SDK build system directly. This is the `TEST_CASES`
+variable that expects a JSON file used in both [microkit-hw-build] and here.
+
+The [microkit-hw-build] action does not build the Microkit SDK, but instead
+a particular example for a particular board from a pre-built Microkit SDK.
+The unpacked Microkit SDK is passed in as the `MICROKIT_SDK` environment variable
+from earlier steps within a GitHub actions workflow. In the Microkit repo's CI
+environment, this is built from source directly, but could be fetched from
+an active release as desired.
+
+[microkit]: https://docs.sel4.systems/projects/microkit/
+[microkit-hw-build]: ../microkit-hw-build/README.md
+[machine queue]: https://github.com/seL4/machine_queue
+
+## Content
+
+The entry point is the script [steps.sh].
+
+The main test driver [build.py] in this directory is shared with microkit-hw-matrix
+and microkit-hw-builds.
+
+[steps.sh]: ./steps.sh
+[build.py]: ./build.py
+
+## Arguments
+
+To add or modify platform options, create a PR to the [Microkit repository].
+
+[Microkit repository]: https://github.com/seL4/microkit
+
+To filter the build variants defined there for a specific run, use one or more
+of the following action inputs:
+
+- `board`: comma separated list of Microkit board names to filter, e.g. `maaxboard,star64`.
+- `config`: comma separated list of Microkit config names, e.g. `debug,release`.
+- `march`: comma separated list of Microkit board architectures, e.g. `aarch64,riscv64,x86_64`.
+- `index`: **(required)** job index in matrix builds (use 0 if no matrix build)
+
+## Environment
+
+The action expects the following environment variables to be set:
+
+- `HW_SSH`: secret SSH key for the CI account to use the machine queue at UNSW.
+- `TEST_CASES`: the JSON output from the [microkit-hw-matrix] 'test_cases' GitHub output.
+- `MICROKIT_SDK`: the path to the microkit SDK containing the examples
+
+[microkit-hw-matrix]: ../microkit-hw-matrix/README.md

--- a/microkit-hw-run/action.yml
+++ b/microkit-hw-run/action.yml
@@ -1,0 +1,32 @@
+# Copyright 2021, Proofcraft Pty Ltd
+# Copyright 2026, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: 'microkit/Hardware Runs'
+description: |
+  Does microkit test runs from previously built images for all hardware test platforms.
+author: Julia Vassiliki <julia.vassiliki@unsw.edu.au>
+
+inputs:
+  board:
+    description: Comma separated list of microkit boards (MICROKIT_BOARD) to run the test for.
+    required: true
+  config:
+    description: Comma separated list of microkit configs (MICROKIT_CONFIG) to run the test for.
+    required: false
+  march:
+    description: Comma separated list of platform marches (from platforms.yml) to run the test for.
+    required: false
+  index:
+    description: job index in matrix build
+    required: true
+  action_name:
+    description: 'internal -- do not use'
+    required: false
+    default: 'microkit-hw-run'
+
+runs:
+  using: 'node24'
+  main: '../js/index.js'
+  post: '../js/post.js'

--- a/microkit-hw-run/action.yml
+++ b/microkit-hw-run/action.yml
@@ -5,7 +5,7 @@
 
 name: 'microkit/Hardware Runs'
 description: |
-  Does microkit test runs from previously built images for all hardware test platforms.
+  Runs Microkit examples from previously built images for all hardware test platforms.
 author: Julia Vassiliki <julia.vassiliki@unsw.edu.au>
 
 inputs:
@@ -16,7 +16,7 @@ inputs:
     description: Comma separated list of microkit configs (MICROKIT_CONFIG) to run the test for.
     required: false
   march:
-    description: Comma separated list of platform marches (from platforms.yml) to run the test for.
+    description: Comma separated list of microkit architectures to run the test for.
     required: false
   index:
     description: job index in matrix build

--- a/microkit-hw-run/build.py
+++ b/microkit-hw-run/build.py
@@ -1,0 +1,211 @@
+# Copyright 2021, Proofcraft Pty Ltd
+# Copyright 2026, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Parse builds.yml and run sel4test hardware builds and runs on each of the build definitions.
+
+Expects seL4-platforms/ to be co-located or otherwise in the PYTHONPATH.
+Expects TEST_CASES environment variable to be a JSON.
+"""
+
+from builds import Build, Run, run_build_script, run_builds, filtered, get_env_filters
+from builds import release_mq_locks, SKIP, build_for_platform
+from platforms import Platform, platforms as sel4_platforms, gh_output
+
+from pathlib import Path
+from pprint import pprint
+from typing import List, Any, Optional
+
+import copy
+import json
+import os
+import sys
+
+
+class MicrokitRun(Run):
+    def hw_run(self, log):
+        build = self.build
+
+        script, final = super().hw_run(log)
+
+        try:
+            if script[0][0] == "tar":
+                script.pop(0)
+        except IndexError:
+            pass
+
+        return (script, final)
+
+
+class MicrokitBuild(Build):
+    def __init__(self, board: str, config: str, march: str, defaults: dict):
+        board_upper = board.upper()
+
+        if sel4_platforms.get(board_upper):
+            platform = board_upper
+        else:
+            for platform_obj in sel4_platforms.values():
+                # print(f"considering sel4 platform board {platform_obj} for board {board}")
+                if board in platform_obj.microkit_boards:
+                    platform = platform_obj.name
+                    break
+            else:
+                raise Exception(
+                    f"unknown platforms.yml entry for microkit board '{board}'"
+                )
+
+        super().__init__(
+            {
+                f"{board_upper}_{config}": {
+                    "platform": platform,
+                    # always 64-bit for microkit at this time
+                    "mode": 64,
+                    "microkit_board": board,
+                    "microkit_config": config,
+                    "microkit_march": march,
+                }
+            },
+            defaults,
+        )
+        self.update_settings()
+
+        self.files = [self.get_image_path()]
+        if march == "x86_64":
+            self.files.insert(
+                0,
+                (
+                    Path(os.environ["MICROKIT_SDK"])
+                    / "board"
+                    / board
+                    / config
+                    / "elf"
+                    / "sel4_32.elf"
+                ).as_posix(),
+            )
+
+    def get_image_path(self) -> str:
+        return (
+            Path(os.environ["GITHUB_WORKSPACE"]) / f"{self.name}.loader.img"
+        ).as_posix()
+
+    def is_disabled(self) -> bool:
+        platform = self.get_platform()
+        return platform.microkit_no_hw_test or ("debug" not in self.microkit_config)
+
+    def hw_run(self, log):
+        return MicrokitRun(self).hw_run(log)
+
+
+def hw_run(manifest_dir: str, build: MicrokitBuild) -> int:
+    """Run one hardware test."""
+
+    if build.is_disabled():
+        print(f"Test {build.name} disabled, skipping.")
+        return SKIP
+
+    script, final = build.hw_run(f"{build.name}")
+
+    return run_build_script(
+        manifest_dir, build, script, final_script=final, junit=False
+    )
+
+
+def test_filter(build: MicrokitBuild) -> bool:
+    plat = build.get_platform()
+
+    if plat.microkit_no_hw_build:
+        return False
+
+    return True
+
+
+def hw_build(manifest_dir: str, build: MicrokitBuild) -> int:
+    """Run one hardware build"""
+
+    MICROKIT_SDK = Path(os.environ["MICROKIT_SDK"])
+    GITHUB_WORKSPACE = Path(os.environ["GITHUB_WORKSPACE"])
+    BUILD_DIR = GITHUB_WORKSPACE / "builds" / build.name
+    microkit_board = build.microkit_board
+    microkit_config = build.microkit_config
+
+    script = [
+        ["mkdir", "-p", BUILD_DIR.as_posix()],
+        [
+            "make",
+            "-C",
+            (MICROKIT_SDK / "example" / "hello").as_posix(),
+            f"BUILD_DIR={BUILD_DIR}",
+            f"MICROKIT_SDK={MICROKIT_SDK}",
+            f"MICROKIT_BOARD={microkit_board}",
+            f"MICROKIT_CONFIG={microkit_config}",
+        ],
+        ["cp", (BUILD_DIR / "loader.img").as_posix(), build.get_image_path()],
+    ]
+
+    return run_build_script(manifest_dir, build, script)
+
+
+def load_builds_microkit(filter_fun=lambda x: True) -> List[MicrokitBuild]:
+    test_cases: list[dict[str, str]] = json.loads(os.environ["TEST_CASES"])
+
+    # keep in sync with action.yml
+    env_filters = get_env_filters(keys=["board", "march", "config"])
+
+    DEFAULTS = {
+        "success": "hello, world",
+        # these should finish quickly
+        "timeout": 120,
+    }
+
+    builds = []
+    for test_case in test_cases:
+        board = test_case["board"]
+        config = test_case["config"]
+        march = test_case["march"]
+
+        build: Optional[MicrokitBuild] = MicrokitBuild(board, config, march, DEFAULTS)
+
+        build = build if filter_fun(build) else None
+        build = filtered(build, env_filters)
+        if build:
+            builds.append(build)
+
+    return builds
+
+
+def to_json(builds: List[MicrokitBuild]) -> str:
+    """Return a GitHub build matrix per enabled hardware platform as GitHub output assignment."""
+
+    boards = sorted(set([(b.microkit_board, b.microkit_march) for b in builds]))
+    matrix = {
+        "include": [{"board": board, "march": march} for (board, march) in boards]
+    }
+
+    return "gh_matrix=" + json.dumps(matrix)
+
+
+# If called as main, run all builds from builds.yml
+if __name__ == "__main__":
+    builds = load_builds_microkit(filter_fun=test_filter)
+
+    if len(builds) == 0:
+        raise Exception("no builds available")
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--dump":
+        pprint(builds)
+        sys.exit(0)
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--matrix":
+        gh_output(to_json(builds))
+        sys.exit(0)
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--hw":
+        sys.exit(run_builds(builds, hw_run))
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--post":
+        release_mq_locks(builds)
+        sys.exit(0)
+
+    sys.exit(run_builds(builds, hw_build))

--- a/microkit-hw-run/build.py
+++ b/microkit-hw-run/build.py
@@ -1,0 +1,213 @@
+# Copyright 2021, Proofcraft Pty Ltd
+# Copyright 2026, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Takes microkit's build_sdk --matrix output and builds + runs an example image
+for each of the boards listed according to enable/disable information in
+the platforms.yml file.
+
+Expects seL4-platforms/ to be co-located or otherwise in the PYTHONPATH.
+Expects TEST_CASES environment variable to be a JSON.
+"""
+
+from builds import Build, Run, run_build_script, run_builds, filtered, get_env_filters
+from builds import release_mq_locks, SKIP, build_for_platform
+from platforms import Platform, platforms as sel4_platforms, gh_output
+
+from pathlib import Path
+from pprint import pprint
+from typing import List, Any, Optional
+
+import copy
+import json
+import os
+import sys
+
+
+class MicrokitRun(Run):
+    def hw_run(self, log):
+        build = self.build
+
+        script, final = super().hw_run(log)
+
+        try:
+            if script[0][0] == "tar":
+                script.pop(0)
+        except IndexError:
+            pass
+
+        return (script, final)
+
+
+class MicrokitBuild(Build):
+    def __init__(self, board: str, config: str, march: str, defaults: dict):
+        board_upper = board.upper()
+
+        if sel4_platforms.get(board_upper):
+            platform = board_upper
+        else:
+            for platform_obj in sel4_platforms.values():
+                # print(f"considering sel4 platform board {platform_obj} for board {board}")
+                if board in platform_obj.microkit_boards:
+                    platform = platform_obj.name
+                    break
+            else:
+                raise Exception(
+                    f"unknown platforms.yml entry for microkit board '{board}'"
+                )
+
+        super().__init__(
+            {
+                f"{board_upper}_{config}": {
+                    "platform": platform,
+                    # always 64-bit for microkit at this time
+                    "mode": 64,
+                    "microkit_board": board,
+                    "microkit_config": config,
+                    "microkit_march": march,
+                }
+            },
+            defaults,
+        )
+        self.update_settings()
+
+        self.files = [self.get_image_path()]
+        if march == "x86_64":
+            self.files.insert(
+                0,
+                (
+                    Path(os.environ["MICROKIT_SDK"])
+                    / "board"
+                    / board
+                    / config
+                    / "elf"
+                    / "sel4_32.elf"
+                ).as_posix(),
+            )
+
+    def get_image_path(self) -> str:
+        return (
+            Path(os.environ["GITHUB_WORKSPACE"]) / f"{self.name}.loader.img"
+        ).as_posix()
+
+    def is_disabled(self) -> bool:
+        platform = self.get_platform()
+        return platform.microkit_no_hw_test or ("debug" not in self.microkit_config)
+
+    def hw_run(self, log):
+        return MicrokitRun(self).hw_run(log)
+
+
+def hw_run(manifest_dir: str, build: MicrokitBuild) -> int:
+    """Run one hardware test."""
+
+    if build.is_disabled():
+        print(f"Test {build.name} disabled, skipping.")
+        return SKIP
+
+    script, final = build.hw_run(f"{build.name}")
+
+    return run_build_script(
+        manifest_dir, build, script, final_script=final, junit=False
+    )
+
+
+def test_filter(build: MicrokitBuild) -> bool:
+    plat = build.get_platform()
+
+    if plat.microkit_no_hw_build:
+        return False
+
+    return True
+
+
+def hw_build(manifest_dir: str, build: MicrokitBuild) -> int:
+    """Run one hardware build"""
+
+    MICROKIT_SDK = Path(os.environ["MICROKIT_SDK"])
+    GITHUB_WORKSPACE = Path(os.environ["GITHUB_WORKSPACE"])
+    BUILD_DIR = GITHUB_WORKSPACE / "builds" / build.name
+    microkit_board = build.microkit_board
+    microkit_config = build.microkit_config
+
+    script = [
+        ["mkdir", "-p", BUILD_DIR.as_posix()],
+        [
+            "make",
+            "-C",
+            (MICROKIT_SDK / "example" / "hello").as_posix(),
+            f"BUILD_DIR={BUILD_DIR}",
+            f"MICROKIT_SDK={MICROKIT_SDK}",
+            f"MICROKIT_BOARD={microkit_board}",
+            f"MICROKIT_CONFIG={microkit_config}",
+        ],
+        ["cp", (BUILD_DIR / "loader.img").as_posix(), build.get_image_path()],
+    ]
+
+    return run_build_script(manifest_dir, build, script)
+
+
+def load_builds_microkit(filter_fun=lambda x: True) -> List[MicrokitBuild]:
+    test_cases: list[dict[str, str]] = json.loads(os.environ["TEST_CASES"])
+
+    # keep in sync with action.yml
+    env_filters = get_env_filters(keys=["board", "march", "config"])
+
+    DEFAULTS = {
+        "success": "hello, world",
+        # these should finish quickly
+        "timeout": 120,
+    }
+
+    builds = []
+    for test_case in test_cases:
+        board = test_case["board"]
+        config = test_case["config"]
+        march = test_case["march"]
+
+        build: Optional[MicrokitBuild] = MicrokitBuild(board, config, march, DEFAULTS)
+
+        build = build if filter_fun(build) else None
+        build = filtered(build, env_filters)
+        if build:
+            builds.append(build)
+
+    return builds
+
+
+def to_json(builds: List[MicrokitBuild]) -> str:
+    """Return a GitHub build matrix per enabled hardware platform as GitHub output assignment."""
+
+    boards = sorted(set([(b.microkit_board, b.microkit_march) for b in builds]))
+    matrix = {
+        "include": [{"board": board, "march": march} for (board, march) in boards]
+    }
+
+    return "gh_matrix=" + json.dumps(matrix)
+
+
+# If called as main, run all builds from the microkit SDK
+if __name__ == "__main__":
+    builds = load_builds_microkit(filter_fun=test_filter)
+
+    if len(builds) == 0:
+        raise Exception("no builds available")
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--dump":
+        pprint(builds)
+        sys.exit(0)
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--matrix":
+        gh_output(to_json(builds))
+        sys.exit(0)
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--hw":
+        sys.exit(run_builds(builds, hw_run))
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--post":
+        release_mq_locks(builds)
+        sys.exit(0)
+
+    sys.exit(run_builds(builds, hw_build))

--- a/microkit-hw-run/post-steps.sh
+++ b/microkit-hw-run/post-steps.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+hw-post-steps.sh

--- a/microkit-hw-run/steps.sh
+++ b/microkit-hw-run/steps.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+hw-steps.sh

--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -709,7 +709,11 @@ def build_for_variant(base_build: Build, variant, filter_fun=lambda x: True) -> 
     return build if filter_fun(build) else None
 
 
-def get_env_filters() -> list:
+DEFAULT_ENV_FILTER_KEYS = ['march', 'arch', 'mode',
+                           'compiler', 'debug', 'platform', 'name', 'app', 'req']
+
+
+def get_env_filters(keys: list[str] = DEFAULT_ENV_FILTER_KEYS) -> list:
     """Process input env variables and return a build filter (list of dict)"""
 
     def get(var: str) -> Optional[str]:
@@ -718,7 +722,6 @@ def get_env_filters() -> list:
     def to_list(string: str) -> list:
         return [s.strip() for s in string.split(',')]
 
-    keys = ['march', 'arch', 'mode', 'compiler', 'debug', 'platform', 'name', 'app', 'req']
     filter = {k: to_list(get(k)) for k in keys if get(k)}
     # 'mode' expects integers:
     if 'mode' in filter:
@@ -776,6 +779,12 @@ def filtered(build: Build, build_filters: dict) -> Optional[Build]:
                         return False
             elif k in ['name', 'app']:
                 if vars(build).get(k) not in v:
+                    return False
+            elif k == 'board':
+                if getattr(build, "microkit_board") not in v:
+                    return False
+            elif k == 'config':
+                if getattr(build, "microkit_config") not in v:
                     return False
             elif not vars(build.get_platform()).get(k):
                 return False

--- a/seL4-platforms/platforms.py
+++ b/seL4-platforms/platforms.py
@@ -57,6 +57,9 @@ class Platform:
         self.req = None
         self.no_hw_test = False
         self.no_hw_build = False
+        self.microkit_no_hw_test = False
+        self.microkit_no_hw_build = False
+        self.microkit_boards = []
         self.settings = {}
         self.__dict__.update(**entries)
         if not self.validate():
@@ -110,6 +113,9 @@ class Platform:
             f"    req: {self.req}",
             f"    no_hw_test: {self.no_hw_test}",
             f"    no_hw_build: {self.no_hw_build}",
+            f"    microkit_no_hw_test: {self.microkit_no_hw_test}",
+            f"    microkit_no_hw_build: {self.microkit_no_hw_build}",
+            f"    microkit_boards: {self.microkit_boards}",
             f"    settings: {self.settings}",
             "  }"
         ]])

--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -385,7 +385,26 @@ platforms:
     image_platform: bcm2711
     march: armv8a
     no_hw_test: true
-    microkit_boards: [rpi4b_1gb, rpi4b_2gb, rpi4b_4gb, rpi4b_8gb]
+    microkit_boards: [rpi4b_1gb, rpi4b_2gb, rpi4b_4gb]
+
+  # microkit only. in general this is somewhat of a hack,
+  # mostly because specifying properties on a per-board level
+  # under microkit_boards is not easily possible.
+  # we cannot test this platform as the RPI4 in our CI is
+  # a 4GB model, not an 8GB model.
+  RPI4_8GB:
+    arch: arm
+    modes: [64]
+    smp: [64]
+    platform: rpi4
+    req: []
+    image_platform: bcm2711
+    march: armv8a
+    # microkit-only
+    no_hw_build: true
+    # cannot be tested
+    microkit_no_hw_test: true
+    microkit_boards: [rpi4b_8gb]
 
   TX1:
     arch: arm

--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -29,12 +29,24 @@ platforms:
     platform: ariane
     march: rv64imac
     no_hw_test: true
+    microkit_no_hw_test: true
 
   CHESHIRE:
     arch: riscv
     modes: [64]
     platform: cheshire
     march: rv64imac
+    no_hw_test: true
+    microkit_no_hw_test: true
+
+  SERENGETI:
+    arch: riscv
+    modes: [64]
+    platform: cheshire
+    req: [serengeti1, serengeti2]
+    march: rv64imac
+    # microkit hw build/test only
+    no_hw_build: true
     no_hw_test: true
 
   SPIKE32:
@@ -63,6 +75,9 @@ platforms:
     march: rv64imac
     no_hw_test: true
     no_hw_build: true
+    microkit_no_hw_test: true
+    microkit_no_hw_build: true
+    microkit_boards: qemu_virt_riscv64
 
   RISCVVIRT32:
     arch: riscv
@@ -121,7 +136,9 @@ platforms:
     platform: rockpro64
     req: [rockpro64a]
     march: armv8a
+    # no board in machine queue
     no_hw_test: true
+    microkit_no_hw_test: true
 
   ROCK3B:
     arch: arm
@@ -131,7 +148,9 @@ platforms:
     platform: rk3568
     req: [rk3568]
     march: armv8a
+    # no board in machine queue
     no_hw_test: true
+    microkit_no_hw_test: true
 
   QUARTZ64:
     arch: arm
@@ -157,6 +176,9 @@ platforms:
     march: armv8a # Cortex-A53 is emulated by default
     no_hw_test: true
     no_hw_build: true
+    microkit_no_hw_test: true
+    microkit_no_hw_build: true
+    microkit_boards: [qemu_virt_aarch64]
 
   IMX8MQ_EVK:
     arch: arm
@@ -188,6 +210,29 @@ platforms:
     platform: imx8mm-evk
     req: [imx8mm]
     march: armv8a
+
+  IMX8MP_EVK:
+    arch: arm
+    modes: [32, 64]
+    smp: [64]
+    platform: imx8mp-evk
+    req: []
+    march: armv8a
+    # there is no board in the machine queue at the moment.
+    no_hw_test: true
+    microkit_no_hw_test: true
+
+  # microkit only
+  IMX8MP_IOTGATE:
+    arch: arm
+    modes: [64]
+    smp: [64]
+    platform: imx8mp-iotgate
+    req: [iotgate1, iotgate3, iotgate4, iotgate5]
+    march: armv8a
+    # microkit only, no seL4
+    no_hw_build: true
+    no_hw_test: true
 
   TQMA8XQP1GB:
     arch: arm
@@ -231,6 +276,7 @@ platforms:
     platform: odroidc2
     req: [odroidc2]
     march: armv8a
+    microkit_boards: [odroidc2]
 
   ODROID_C4:
     arch: arm
@@ -240,6 +286,7 @@ platforms:
     platform: odroidc4
     req: [odroidc4_1, odroidc4_2]
     march: armv8a
+    microkit_boards: [odroidc4]
 
   ODROID_XU:
     arch: arm
@@ -277,10 +324,31 @@ platforms:
     platform: zynqmp
     req: [zcu102_2]
     march: armv8a
+    microkit_boards: [zcu102]
     # The ZCU102 in machine queue expects a binary image
     # settings:
     # Sel4testAllowSettingsOverride: true
     # ElfloaderImage: "binary"
+
+  KRIA_K26:
+    arch: arm
+    modes: [64]
+    aarch_hyp: [64]
+    platform: zynqmp
+    march: armv8a
+    # not in seL4 tooling
+    no_hw_build: true
+    # We don't have any of these physical boards to test against
+    microkit_no_hw_test: true
+
+  ULTRA96V2:
+    arch: arm
+    modes: [64]
+    aarch_hyp: [64]
+    platform: zynqmp
+    march: armv8a
+    # We don't have any of these physical boards to test against
+    microkit_no_hw_test: true
 
   ZYNQMP106:
     arch: arm
@@ -317,6 +385,7 @@ platforms:
     image_platform: bcm2711
     march: armv8a
     no_hw_test: true
+    microkit_boards: [rpi4b_1gb, rpi4b_2gb, rpi4b_4gb, rpi4b_8gb]
 
   TX1:
     arch: arm
@@ -344,6 +413,7 @@ platforms:
     req: [skylake, haswell3, haswell4, skylake3]
     has_simulation: true
     march: nehalem
+    microkit_boards: [x86_64_generic, x86_64_generic_vtx]
 
 # platforms where MCS is wholly unsupported
 # (for platforms with partial support see sel4test-hw/build.py and comments below)

--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -29,12 +29,24 @@ platforms:
     platform: ariane
     march: rv64imac
     no_hw_test: true
+    microkit_no_hw_test: true
 
   CHESHIRE:
     arch: riscv
     modes: [64]
     platform: cheshire
     march: rv64imac
+    no_hw_test: true
+    microkit_no_hw_test: true
+
+  SERENGETI:
+    arch: riscv
+    modes: [64]
+    platform: cheshire
+    req: [serengeti1, serengeti2]
+    march: rv64imac
+    # microkit hw build/test only
+    no_hw_build: true
     no_hw_test: true
 
   SPIKE32:
@@ -63,6 +75,9 @@ platforms:
     march: rv64imac
     no_hw_test: true
     no_hw_build: true
+    microkit_no_hw_test: true
+    microkit_no_hw_build: true
+    microkit_boards: qemu_virt_riscv64
 
   RISCVVIRT32:
     arch: riscv
@@ -121,7 +136,9 @@ platforms:
     platform: rockpro64
     req: [rockpro64a]
     march: armv8a
+    # no board in machine queue
     no_hw_test: true
+    microkit_no_hw_test: true
 
   ROCK3B:
     arch: arm
@@ -131,7 +148,9 @@ platforms:
     platform: rk3568
     req: [rk3568]
     march: armv8a
+    # no board in machine queue
     no_hw_test: true
+    microkit_no_hw_test: true
 
   QUARTZ64:
     arch: arm
@@ -157,6 +176,9 @@ platforms:
     march: armv8a # Cortex-A53 is emulated by default
     no_hw_test: true
     no_hw_build: true
+    microkit_no_hw_test: true
+    microkit_no_hw_build: true
+    microkit_boards: [qemu_virt_aarch64]
 
   IMX8MQ_EVK:
     arch: arm
@@ -188,6 +210,29 @@ platforms:
     platform: imx8mm-evk
     req: [imx8mm]
     march: armv8a
+
+  IMX8MP_EVK:
+    arch: arm
+    modes: [32, 64]
+    smp: [64]
+    platform: imx8mp-evk
+    req: []
+    march: armv8a
+    # there is no board in the machine queue at the moment.
+    no_hw_test: true
+    microkit_no_hw_test: true
+
+  # microkit only
+  IMX8MP_IOTGATE:
+    arch: arm
+    modes: [64]
+    smp: [64]
+    platform: imx8mp-iotgate
+    req: [iotgate1, iotgate3, iotgate4, iotgate5]
+    march: armv8a
+    # microkit only, no seL4
+    no_hw_build: true
+    no_hw_test: true
 
   TQMA8XQP1GB:
     arch: arm
@@ -231,6 +276,7 @@ platforms:
     platform: odroidc2
     req: [odroidc2]
     march: armv8a
+    microkit_boards: [odroidc2]
 
   ODROID_C4:
     arch: arm
@@ -240,6 +286,7 @@ platforms:
     platform: odroidc4
     req: [odroidc4_1, odroidc4_2]
     march: armv8a
+    microkit_boards: [odroidc4]
 
   ODROID_XU:
     arch: arm
@@ -277,10 +324,31 @@ platforms:
     platform: zynqmp
     req: [zcu102_2]
     march: armv8a
+    microkit_boards: [zcu102]
     # The ZCU102 in machine queue expects a binary image
     # settings:
     # Sel4testAllowSettingsOverride: true
     # ElfloaderImage: "binary"
+
+  KRIA_K26:
+    arch: arm
+    modes: [64]
+    aarch_hyp: [64]
+    platform: zynqmp
+    march: armv8a
+    # not in seL4 tooling
+    no_hw_build: true
+    # We don't have any of these physical boards to test against
+    microkit_no_hw_test: true
+
+  ULTRA96V2:
+    arch: arm
+    modes: [64]
+    aarch_hyp: [64]
+    platform: zynqmp
+    march: armv8a
+    # We don't have any of these physical boards to test against
+    microkit_no_hw_test: true
 
   ZYNQMP106:
     arch: arm
@@ -326,6 +394,26 @@ platforms:
     image_platform: bcm2711
     march: armv8a
     no_hw_test: true
+    microkit_boards: [rpi4b_1gb, rpi4b_2gb, rpi4b_4gb]
+
+  # microkit only. in general this is somewhat of a hack,
+  # mostly because specifying properties on a per-board level
+  # under microkit_boards is not easily possible.
+  # we cannot test this platform as the RPI4 in our CI is
+  # a 4GB model, not an 8GB model.
+  RPI4_8GB:
+    arch: arm
+    modes: [64]
+    smp: [64]
+    platform: rpi4
+    req: []
+    image_platform: bcm2711
+    march: armv8a
+    # microkit-only
+    no_hw_build: true
+    # cannot be tested
+    microkit_no_hw_test: true
+    microkit_boards: [rpi4b_8gb]
 
   TX1:
     arch: arm
@@ -353,6 +441,7 @@ platforms:
     req: [skylake, haswell3, haswell4, skylake3]
     has_simulation: true
     march: nehalem
+    microkit_boards: [x86_64_generic, x86_64_generic_vtx]
 
 # platforms where MCS is wholly unsupported
 # (for platforms with partial support see sel4test-hw/build.py and comments below)


### PR DESCRIPTION
- Adds seL4-platforms knowledge about microkit
- Adds actions for use by Microkit CI

Should be merged before https://github.com/seL4/microkit/pull/475.

The 'test' here is rather simple for the moment: it simply runs the 'Hello, World!' example (which works only in debug) and checks the output matches. The goal is to eventually improve this, but it at least tests that the debug boot flow works; which is better than nothing.

- [x] do we want to set me/~~Ivan~~ (Ivan is leaving) up as codeowners for this folder?