### PR TITLE
python: always install in a virtualenv

### DIFF
--- a/aws-proofs/steps.sh
+++ b/aws-proofs/steps.sh
@@ -13,6 +13,7 @@ if [ "${GITHUB_EVENT_NAME}" = "pull_request_target" ] ||
    [ "${GITHUB_EVENT_NAME}" = "pull_request" ]
 then
   echo "::group::PR info"
+  . ${SCRIPTS}/setup-python-venv.sh
   pip3 install -U PyGithub
   export INPUT_EXTRA_PRS="$(get-prs)"
   echo "::endgroup::"

--- a/gitlint/steps.sh
+++ b/gitlint/steps.sh
@@ -12,6 +12,7 @@ echo "::group::Setting up"
 install-python.sh
 
 echo "Installing gitlint tool"
+. ${SCRIPTS}/setup-python-venv.sh
 pip3 install -q gitlint
 
 checkout.sh

--- a/l4v-deploy/steps.sh
+++ b/l4v-deploy/steps.sh
@@ -14,7 +14,8 @@ chmod a+x ~/bin/repo
 
 PATH=~/bin:"${SCRIPTS}/../l4v-deploy":$PATH
 
-pip3 install --user lxml
+. ${SCRIPTS}/setup-python-venv.sh
+pip3 install lxml
 
 if [ -z "${GH_SSH}" ]; then
   echo "No 'GH_SSH' key provided" >&2

--- a/license-check/steps.sh
+++ b/license-check/steps.sh
@@ -10,6 +10,7 @@ echo "::group::Setting up"
 install-python.sh
 
 echo "Installing reuse tool"
+. ${SCRIPTS}/setup-python-venv.sh
 pip3 install -q reuse==5.0.2
 
 checkout.sh

--- a/manifest-deploy/steps.sh
+++ b/manifest-deploy/steps.sh
@@ -28,7 +28,8 @@ echo "Fetching seL4_release repo"
 git clone --depth 1 ssh://git@github.com/seL4/seL4_release
 
 echo "Installing python dependencies"
-pip3 install --user -r ${GITHUB_WORKSPACE}/seL4_release/requirements.txt
+. ${SCRIPTS}/setup-python-venv.sh
+pip3 install -r ${GITHUB_WORKSPACE}/seL4_release/requirements.txt
 
 echo "Install doxygen"
 sudo apt-get install -qq doxygen

--- a/repo-checkout/steps.sh
+++ b/repo-checkout/steps.sh
@@ -14,6 +14,7 @@ curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
 chmod a+x ~/bin/repo
 PATH=~/bin:$PATH
 
+. ${SCRIPTS}/setup-python-venv.sh
 pip3 install -U PyGithub
 
 echo "::endgroup::"

--- a/scripts/hw-steps.sh
+++ b/scripts/hw-steps.sh
@@ -25,7 +25,8 @@ export ACTION_DIR="${SCRIPTS}/.."
 
 # python env
 sudo apt-get install -y --no-install-recommends libffi-dev
-pip3 install --user "junitparser==3.*" sel4-deps
+. ${SCRIPTS}/setup-python-venv.sh
+pip3 install "junitparser==3.*" sel4-deps
 export PYTHONPATH="${ACTION_DIR}/seL4-platforms"
 echo "::endgroup::"
 

--- a/scripts/install-python.sh
+++ b/scripts/install-python.sh
@@ -14,6 +14,7 @@ sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1
 sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
 python3 --version
 
+. ${SCRIPTS}/setup-python-venv.sh
 # setuptools and wheel versions must be matched to working releases
 # we need an old version of setuptools (see PR seL4/ci-actions#381)
 # and newer versions of wheel removes the bdist_wheel implementation

--- a/scripts/setup-python-venv.sh
+++ b/scripts/setup-python-venv.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Copyright 2026, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Sets up a python virtual environment in ${RUNNER_TEMP}/venv
+# Does nothing if VIRTUAL_ENV is already set, which means we are in a virtual
+# environment already.
+# Expects to be sourced with '.' or 'source', as it modifies the environment.
+# Does not pass --system-site-packages so is isolated from whatever is installed
+# in the system itself.
+
+set -e
+
+if [ -z "${VIRTUAL_ENV}" ]; then
+    python3 -m venv "${RUNNER_TEMP}/venv"
+    . "${RUNNER_TEMP}/venv/bin/activate"
+fi

--- a/sel4bench-web/steps.sh
+++ b/sel4bench-web/steps.sh
@@ -10,7 +10,8 @@ export ACTION_DIR="${SCRIPTS}/.."
 
 # python env
 sudo apt-get install -y --no-install-recommends libffi-dev
-pip3 install --user "junitparser==3.*" sel4-deps
+. ${SCRIPTS}/setup-python-venv.sh
+pip3 install "junitparser==3.*" sel4-deps
 export PYTHONPATH="${ACTION_DIR}/seL4-platforms"
 echo "::endgroup::"
 

--- a/sel4test-hw-matrix/steps.sh
+++ b/sel4test-hw-matrix/steps.sh
@@ -12,7 +12,8 @@ export ACTION_DIR="${SCRIPTS}/.."
 
 # python env
 sudo apt-get install -y --no-install-recommends libffi-dev
-pip3 install --user "junitparser==3.*" sel4-deps
+. ${SCRIPTS}/setup-python-venv.sh
+pip3 install "junitparser==3.*" sel4-deps
 export PYTHONPATH="${ACTION_DIR}/seL4-platforms"
 echo "::endgroup::"
 

--- a/style/steps.sh
+++ b/style/steps.sh
@@ -10,6 +10,7 @@ echo "::group::Setting up"
 install-python.sh
 
 echo "Installing seL4 python deps"
+. ${SCRIPTS}/setup-python-venv.sh
 pip3 install -q sel4-deps
 
 echo "Installing astyle"


### PR DESCRIPTION
This stops break-system-packages warnings and works better in self-hosted runner environments which aren't sandboxed.

Friend to https://github.com/seL4/ci-actions/pull/458