### PR TITLE
Make 'run_cmd' operate without universal newlines

### DIFF
--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -430,13 +430,17 @@ def run_cmd(cmd, run: Union[Run, Build], prev_output: Optional[str] = None) -> i
         sys.stdout.flush()
         # Print output as it arrives. Some of the build commands take too long to
         # wait until all output is there. Keep stderr separate, but flush it.
-        process = subprocess.Popen(cmd, text=True, stdout=subprocess.PIPE,
-                                   stderr=sys.stderr, bufsize=1)
+        # Opens in binary mode; the child might end up messing with the pty
+        # so that it is in raw mode and expects \r\n for a newline, so we can't
+        # use the text= option with line buffering and universal newlines.
+        # Python is however helpful and iterating over process.stdout does
+        # a line-at-a-time as we desire, so we just need to decode bytes ourselves.
+        # Disable buffering so we don't hit issues with unflushed output.
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=sys.stderr, bufsize=0)
         lines = []
         for line in process.stdout:
-            line = line.rstrip()
-            lines.append(line)
-            print(line)
+            lines.append(line.decode().rstrip())
+            sys.stdout.buffer.write(line)
             sys.stdout.flush()
             sys.stderr.flush()
         ret = process.wait()


### PR DESCRIPTION
In 'text' mode (an alias for universal_newlines), Python converts all \r\n sequences into just \n, under the expectation that on Linux it is not necessary to explicit emit a carriage return (and that this would be consistent with other platforms where it does similar).

However, this is not always true: if `stty -onlcr` is set, then newline (\n) does not automatically emit a carriage return (\r). Our machine queue scripts (linked below) explicitly set `-onlcr`, so a \r is also needed for \n to behave as expected. But with universal newlines on, the \r emitted by the other end of `mq.sh` ends up being stripped.

https://github.com/seL4/machine_queue/blob/master/scripts/remote#L16

We turn off 'text'/'universal_newlines' mode, leaving the output in raw binary (which also necessitates disabling line buffering as python does not support that, and so we disable all buffering entirely); then we decode() to text as necessary for the lines return-value, and print binary to our stdout.

This is necessary to make the [local CI runner I added for microkit](https://github.com/seL4/microkit/pull/475/changes/4417c01663c6b33be856c61ea91f74f8cec7636c) to emit output that does not perform the staircase output when \r is not being emitted. 