### PR TITLE
seL4-manual: add texlive-plain-generic for trixie

### DIFF
--- a/seL4-manual/Dockerfile
+++ b/seL4-manual/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        doxygen \
        texlive \
+       texlive-plain-generic \
        texlive-fonts-extra \
        texlive-latex-extra \
     && apt-get clean autoclean \


### PR DESCRIPTION
The file tracklang.sty is no longer included in the main texlive package in Debian trixie and needs texlive-plain-generic.