### PR TITLE
workflows: use ${{ variable }} not invalid $${{

### DIFF
--- a/.github/workflows/sel4bench-hw.yml
+++ b/.github/workflows/sel4bench-hw.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           req: ${{ matrix.req }}
-          index: $${{ strategy.job-index }}
+          index: ${{ strategy.job-index }}
         env:
           HW_SSH: ${{ secrets.HW_SSH }}
       - name: Upload results

--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -117,6 +117,6 @@ jobs:
           platform: ${{ matrix.platform }}
           compiler: ${{ matrix.compiler }}
           mode: ${{ matrix.mode }}
-          index: $${{ strategy.job-index }}
+          index: ${{ strategy.job-index }}
         env:
           HW_SSH: ${{ secrets.HW_SSH }}

--- a/camkes-hw/README.md
+++ b/camkes-hw/README.md
@@ -103,7 +103,7 @@ jobs:
         uses: seL4/ci-actions/camkes-hw@master
         with:
           platform: ${{ matrix.platform }}
-          index: $${{ strategy.job-index }}
+          index: ${{ strategy.job-index }}
         env:
           HW_SSH: ${{ secrets.HW_SSH }}
 ```

--- a/camkes-vm-hw/README.md
+++ b/camkes-vm-hw/README.md
@@ -89,7 +89,7 @@ jobs:
         uses: seL4/ci-actions/camkes-hw@master
         with:
           name: ${{ matrix.name }}
-          index: $${{ strategy.job-index }}
+          index: ${{ strategy.job-index }}
         env:
           HW_SSH: ${{ secrets.HW_SSH }}
 ```

--- a/trigger/README.md
+++ b/trigger/README.md
@@ -92,5 +92,5 @@ jobs:
     steps:
     - uses: seL4/ci-actions/trigger@master
       with:
-        token: $${{ secrets.REPO_TOKEN }}
+        token: ${{ secrets.REPO_TOKEN }}
 ```

--- a/webserver-hw/README.md
+++ b/webserver-hw/README.md
@@ -90,7 +90,7 @@ jobs:
         uses: seL4/ci-actions/webserver-hw@master
         with:
           platform: ${{ matrix.platform }}
-          index: $${{ strategy.job-index }}
+          index: ${{ strategy.job-index }}
         env:
           HW_SSH: ${{ secrets.HW_SSH }}
 ```


### PR DESCRIPTION
I'm not entirely sure how this worked... but I guess GitHub ignores the extra $ sign.