### PR TITLE
c-parser: fix AARCH64-ZYNQMP build

### DIFF
--- a/cparser-run/build.py
+++ b/cparser-run/build.py
@@ -18,6 +18,9 @@ import sys
 def run_cparser(manifest_dir: str, build):
     """Single run of the C Parser test, for one build definition"""
 
+    if not build.get_mode():
+        raise ValueError("Build has no defined mode")
+
     script = [
         ["../init-build.sh"] + build.settings_args(),
         ["ninja", "kernel_all_pp_wrapper"],

--- a/cparser-run/builds.yml
+++ b/cparser-run/builds.yml
@@ -41,6 +41,7 @@ builds:
 
 - AARCH64-ZYNQMP:
     platform: ZYNQMP
+    mode: 64
     l4v_arch: AARCH64
 
 - AARCH32HYP-TK1:


### PR DESCRIPTION
The AARCH64-ZYNQMP build did not specify a mode, and since the ZYNQMP platform is available for both modes (32/64), there is no default mode. Without mode, no default build arguments were set.
