### PR TITLE
platforms: hide ULTRA96v2 from seL4

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -347,6 +347,8 @@ platforms:
     aarch_hyp: [64]
     platform: zynqmp
     march: armv8a
+    # not in seL4 tooling
+    no_hw_build: true
     # We don't have any of these physical boards to test against
     microkit_no_hw_test: true
 


### PR DESCRIPTION
This just builds another duplicate ZynqMP image and we don't have any of the actual boards to run.

This caused CI failure on this board:

https://github.com/seL4/seL4/actions/runs/26268430158/job/77321756193