### PR TITLE
repo-checkout: allow specifying depth

### DIFF
--- a/repo-checkout/README.md
+++ b/repo-checkout/README.md
@@ -27,6 +27,7 @@ The steps of this action are defined in [steps.sh].
 
 - `manifest_repo` (required): the manifest repository to check out (e.g. 'sel4test-manifest')
 - `manifest`: the manifest file to use (default `master.xml`)
+- `depth`: the depth of the checkout of each repository in the manifest (default `1`)
 - `sha:`: override sha to advance PR repo to (e.g. sha for `seL4` repo in `seL4/sel4test-manifest`
           if seL4 is the repo the action is called from)
 

--- a/repo-checkout/steps.sh
+++ b/repo-checkout/steps.sh
@@ -30,6 +30,7 @@ else
 fi
 export REPO_MANIFEST="${INPUT_MANIFEST}"
 export REPO_BRANCH="${INPUT_MANIFEST_BRANCH}"
+export REPO_DEPTH="${INPUT_MANIFEST_DEPTH}"
 checkout-manifest.sh
 
 fetch-branches.sh


### PR DESCRIPTION
Microkit CI needs full depth to be able to compute the SDK version.