### PR TITLE
link-check: use GITHUB_WORKSPACE for checkout

### DIFF
--- a/link-check/steps.sh
+++ b/link-check/steps.sh
@@ -7,8 +7,6 @@
 set -e
 
 echo "::group::Setting up"
-mkdir -p /repo
-cd /repo
 checkout.sh
 
 # get ignored input files from .linkcheck-ignore.yml


### PR DESCRIPTION
Use the `GITHUB_WORKSPACE` directory for repo checkout and link check run so that the generated `.lycheecache` is available outside the container for the github/cache action to pick up and make persistent.