### PR TITLE
link-check: mark workspace dir as safe

### DIFF
--- a/link-check/steps.sh
+++ b/link-check/steps.sh
@@ -7,6 +7,8 @@
 set -e
 
 echo "::group::Setting up"
+# avoid "fatal: detected dubious ownership in repository at '/github/workspace'"
+git config --global --add safe.directory ${GITHUB_WORKSPACE}
 checkout.sh
 
 # get ignored input files from .linkcheck-ignore.yml


### PR DESCRIPTION
git complains about ownership of the mounted workspace directory.

I have a feeling this was why I did the `mkdir /repo` thing initially.

