### PR TITLE
sel4test-hw: skip x86 32-bit SMP + hyp

### DIFF
--- a/sel4test-hw/build.py
+++ b/sel4test-hw/build.py
@@ -106,7 +106,8 @@ def build_filter(build: Build) -> bool:
 
     if plat.arch == 'x86':
         # Bamboo config says no VTX for verification
-        if build.is_hyp() and build.is_verification():
+        # The kernel does not compile for 32-bit SMP + hyp.
+        if build.is_hyp() and (build.is_verification() or (build.get_mode() == 32 and build.is_smp())):
             return False
 
     if plat.arch == 'riscv':


### PR DESCRIPTION
64-bit seems to be fine, but 32-bit does not even compile:
```
In file included from /github/workspace/kernel/include/arch/x86/arch/kernel/elf.h:10,
                   from /github/workspace/kernel/src/arch/x86/32/kernel/elf.c:7:
  /github/workspace/kernel/include/arch/x86/arch/32/mode/kernel/elf.h:41:28: error: unterminated argument list invoking macro "NODE_STATE"
     41 | } Elf32_Phdr_t, Elf_Phdr_t;
        |                            ^
```

This compile error also occurs for 15.0.0 seL4, so it is not a recent regression.