### PR TITLE
sel4test-hw-run: re-enable x86 32-bit hyp + vtx

### DIFF
--- a/sel4test-hw/build.py
+++ b/sel4test-hw/build.py
@@ -106,8 +106,7 @@ def build_filter(build: Build) -> bool:
 
     if plat.arch == 'x86':
         # Bamboo config says no VTX for verification
-        # The kernel does not compile for 32-bit SMP + hyp.
-        if build.is_hyp() and (build.is_verification() or (build.get_mode() == 32 and build.is_smp())):
+        if build.is_hyp() and build.is_verification():
             return False
 
     if plat.arch == 'riscv':


### PR DESCRIPTION
The kernel compile error should have been fixed now.

Ref: https://github.com/seL4/ci-actions/pull/482 and https://github.com/seL4/seL4/pull/1678