### PR TITLE
hw-tests: increase default timeout to 20min

### DIFF
--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -59,7 +59,7 @@ class Build:
         self.success = None
         self.error = None
         self.settings = {}
-        self.timeout = 900
+        self.timeout = 1200
         self.no_hw_test = False
         self.image_base_name = "sel4test-driver"
         [self.name] = entries.keys()


### PR DESCRIPTION
Apparently two of the boards are slow enough to boot that they might hit 15min.