### PR TITLE
builds: reduce machine queue ssh connections

### DIFF
--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -266,16 +266,13 @@ class Run:
 
         return [
             ['tar', 'xvzf', f"../{self.build.name}-images.tar.gz"],
-            mq_print_lock(machine),
-            mq_lock(machine),
             mq_run(build.success, machine, build.files,
                    completion_timeout=build.timeout,
-                   lock_held=True,
                    key=job_key(),
                    log=log,
                    error_str=build.error)
         ], [
-            mq_release(machine)
+            # lock release is done in run command
         ]
 
 


### PR DESCRIPTION
Reduce number of ssh connections to the machine queue, because the back-end server is running out of ssh sessions.

The previous info/lock/run/release cycle can all be done within just the `run` command, which can internally reduce the number of ssh connections that are made.
