### PR TITLE
sel4test-hw: tighter timeout

### DIFF
--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -264,15 +264,19 @@ class Run:
             return [['echo', f"Specify list of machines instead of pool for {self.name}."],
                     ['exit', '1']], []
 
+        # acquire/release lock separately, so that we can measure the time taken
+        # for the actual test run without lock wait time.
         return [
             ['tar', 'xvzf', f"../{self.build.name}-images.tar.gz"],
+            mq_lock(machine),
             mq_run(build.success, machine, build.files,
                    completion_timeout=build.timeout,
+                   lock_held=True,
                    key=job_key(),
                    log=log,
                    error_str=build.error)
         ], [
-            # lock release is done in run command
+            mq_release(machine)
         ]
 
 
@@ -304,8 +308,6 @@ def release_mq_locks(runs: List[Union[Run, Build]]):
             run(mq_cancel(machine))
             # release any locks we already have claimed
             run(mq_release(machine))
-            # show lock status (should now show "free" or "locked for another job")
-            run(mq_print_lock(machine))
 
 
 def get_machine(req):

--- a/sel4test-hw/build.py
+++ b/sel4test-hw/build.py
@@ -57,6 +57,10 @@ def hw_run(manifest_dir: str, build: Build):
         print(f"Build {build.name} is verification+SMP, skipping.")
         return SKIP
 
+    # 5 min timeout for the `mq.sh run` command without lock wait time
+    # most boards finish any config within 1 min, slowest in 14k runs (hifive) ~3 min
+    # reserve some extra for occasional reboot failures
+    build.timeout = 300
     script, final = build.hw_run(junit_results)
 
     return run_build_script(manifest_dir, build, script, final_script=final, junit=True)


### PR DESCRIPTION
Based on log analysis of the last 14k sel4test runs overall, 5 min is plenty.

Also oartially revert https://github.com/seL4/ci-actions/commit/fb23f0803d3fd7a613dc134b369d4bca7180a849, only remove lock info print operations (these are redundant). Acquiring/releasing the lock separately lets us accurately measure the time taken for the actual hardware runs, which is important for figuring out what the timeouts should be.