### PR TITLE
hw-post-steps: set up junitparser

### DIFF
--- a/scripts/hw-post-steps.sh
+++ b/scripts/hw-post-steps.sh
@@ -8,14 +8,20 @@
 # generic steps to release mq lock at the end of a hardware run in case the job was cancelled
 # expects a standard `build.py --post` invocation to work in directory INPUT_ACTION_NAME
 
+# python env
+echo "::group::Setting up"
+export ACTION_DIR="${SCRIPTS}/.."
+sudo apt-get install -y --no-install-recommends libffi-dev
+. ${SCRIPTS}/setup-python-venv.sh
+pip3 install "junitparser==3.*"
+export PYTHONPATH="${ACTION_DIR}/seL4-platforms"
+echo "::endgroup::"
+
 echo "::group::Releasing mq lock"
 # mq setup
 export PATH="$(pwd)/machine_queue":$PATH
 . setup-hw-ssh.sh
 
-# python
-export ACTION_DIR="${SCRIPTS}/.."
-export PYTHONPATH="${ACTION_DIR}/seL4-platforms"
 python3 "${ACTION_DIR}/${INPUT_ACTION_NAME}/build.py" --post
 
 echo "::endgroup::"


### PR DESCRIPTION
The build.py invocation for jobs with hardware runs depends on junitparser and is failing.