### PR TITLE
camkes-unit: remove nosetests invocation

### DIFF
--- a/camkes-unit/steps.sh
+++ b/camkes-unit/steps.sh
@@ -22,4 +22,4 @@ echo "      capdl: $(git -C ../capdl rev-parse --short HEAD)"
 export PYTHONPATH=../capdl/python-capdl-tool
 echo "::endgroup::"
 
-nosetests --exe --ignore-file=testvisualcamkes.py
+python3 alltests.py


### PR DESCRIPTION
`nosetests` is no longer available. Use alltests.py directly instead, which also happens to pick up tests that nosetests missed.