### PR TITLE
builds.py: fix markdown table syntax

### DIFF
--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -974,7 +974,7 @@ def job_failure_summary() -> Optional[str]:
         "## Test failures",
         "",
         "| Config | | Causes | Failed | Succeeded | Skipped |",
-        "| --- | --- | --- | --- | --- | --- | --- |",
+        "| --- | --- | --- | --- | --- | --- |",
     ]
     for summary in failed + passed:
         causes = (cause(summary.name, c, detail) for c, detail in summary.causes)


### PR DESCRIPTION
Number of header columns did not line up with next row.