### PR TITLE
thylint: add find_names to list of diagnostics

### DIFF
--- a/thylint/thylint.py
+++ b/thylint/thylint.py
@@ -107,6 +107,7 @@ diag_words = (
         'show_types',
         'show_sorts',
         'show_consts',
+        'find_names',
     ])
 )
 


### PR DESCRIPTION
A find_names command is almost always for interactive diagnostics and not intended to be checked in.