### PR TITLE
sel4test-hw: add build subgroups to speed up armv8 builds 

### DIFF
--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -74,15 +74,16 @@ jobs:
         xml: ${{ needs.code.outputs.xml }}
         march: ${{ matrix.march }}
         compiler: ${{ matrix.compiler }}
+        subgroup: ${{ matrix.subgroup }}
     - name: Upload images
       uses: actions/upload-artifact@v7
       with:
-        name: images-sel4test-${{ matrix.march }}-${{ matrix.compiler }}
+        name: images-sel4test-${{ matrix.march }}-${{ matrix.compiler }}${{ matrix.subgroup && format('-{0}', matrix.subgroup) }}
         path: '*-images.tar.gz'
     - name: Upload kernel.elf files
       uses: actions/upload-artifact@v7
       with:
-        name: kernel.elf-sel4test-${{ matrix.march }}-${{ matrix.compiler }}
+        name: kernel.elf-sel4test-${{ matrix.march }}-${{ matrix.compiler }}${{ matrix.subgroup && format('-{0}', matrix.subgroup) }}
         path: '*-kernel.elf'
 
   the_matrix:
@@ -118,7 +119,7 @@ jobs:
       - name: Download image
         uses: actions/download-artifact@v8
         with:
-          name: images-sel4test-${{ matrix.march }}-${{ matrix.compiler }}
+          name: images-sel4test-${{ matrix.march }}-${{ matrix.compiler }}${{ matrix.subgroup && format('-{0}', matrix.subgroup) }}
       - name: Run
         uses: seL4/ci-actions/sel4test-hw-run@master
         with:

--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -44,10 +44,21 @@ jobs:
         manifest: master.xml
         sha: ${{ github.event.pull_request.head.sha }}
 
+  build-matrix:
+    name: Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+    - id: matrix
+      uses: seL4/ci-actions/sel4test-hw-matrix@master
+      with:
+        matrix: build
+
   hw-build:
     name: HW Build
     runs-on: ubuntu-latest
-    needs: code
+    needs: [code, build-matrix]
     # To reduce the load (especially on the machine queue) we cancel any older
     # runs of this workflow for the current PR.
     concurrency:
@@ -55,10 +66,7 @@ jobs:
       cancel-in-progress: true
     strategy:
       fail-fast: false
-      matrix:
-        # There is no "rv32imac" hardware yet.
-        march: [armv7a, armv8a, nehalem, rv64imac]
-        compiler: [gcc, clang]
+      matrix: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
     steps:
     - name: Build
       uses: seL4/ci-actions/sel4test-hw@master

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The following GitHub actions are available:
 - [seL4 Manual](seL4-manual/): build seL4 PDF manual
 - [seL4Test Hardware Builds](sel4test-hw/): sel4test image builds
 - [seL4Test Hardware Runs](sel4test-hw-run/): sel4test hardware runs
-- [seL4Test Hardware Run Matrix](sel4test-hw-matrix/): matrix for sel4test hardware runs
+- [seL4Test Hardware Matrix](sel4test-hw-matrix/): matrix for sel4test hardware builds and runs
 - [seL4Test Simulation](sel4test-sim/): sel4test simulations for platforms with a simulation binary
 - [Standalone Kernel](standalone-kernel/): standalone seL4 kernel compilation
 - [Style](style/): coding style checks of the seL4 Foundation

--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -772,8 +772,8 @@ def build_for_variant(base_build: Build, variant, filter_fun=lambda x: True) -> 
     return build if filter_fun(build) else None
 
 
-DEFAULT_ENV_FILTER_KEYS = ['march', 'arch', 'mode',
-                           'compiler', 'debug', 'platform', 'name', 'app', 'req']
+DEFAULT_ENV_FILTER_KEYS = ['march', 'arch', 'mode', 'compiler', 'debug', 'platform',
+                           'name', 'app', 'req', 'subgroup']
 
 
 def get_env_filters(keys: list[str] = DEFAULT_ENV_FILTER_KEYS) -> list:
@@ -835,6 +835,9 @@ def filtered(build: Build, build_filters: dict) -> Optional[Build]:
                     return False
             elif k == 'domains':
                 if (v == '') == build.is_domains():
+                    return False
+            elif k == 'subgroup':
+                if str(build.get_platform().subgroup) not in v:
                     return False
             elif k == 'req':
                 for req in v:

--- a/seL4-platforms/platforms.py
+++ b/seL4-platforms/platforms.py
@@ -54,6 +54,7 @@ class Platform:
         self.image_platform = None
         self.has_simulation = False
         self.march = None
+        self.subgroup = None
         self.req = None
         self.no_hw_test = False
         self.no_hw_build = False

--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -17,7 +17,8 @@ architectures: [x86, arm, riscv]
 #     platform: name; required
 #     image_platform: name; optional
 #     has_simulation: boolean; optional; (null = false); platform has a simulation
-#     march: string; optional
+#     march: string; optional; used for build matrix grouping only, not an actual build parameter
+#     subgroup: int; optional; used for further build matrix sub-grouping
 #     req: list of string; optional; names of test boards in machine queue
 #     no_hw_test: optional; (null = false); no hw test on this platform
 #     no_hw_build: optional; (null = false); no hw build for this platform (implies no_hw_test)
@@ -137,6 +138,7 @@ platforms:
     platform: rockpro64
     req: [rockpro64a]
     march: armv8a
+    subgroup: 4
     # no board in machine queue
     no_hw_test: true
     microkit_no_hw_test: true
@@ -149,6 +151,7 @@ platforms:
     platform: rk3568
     req: [rk3568]
     march: armv8a
+    subgroup: 3
     # no board in machine queue
     no_hw_test: true
     microkit_no_hw_test: true
@@ -158,6 +161,7 @@ platforms:
     modes: [64]
     platform: quartz64
     march: armv8a
+    subgroup: 1
     no_hw_test: true
 
   ARMVIRT32:
@@ -175,6 +179,7 @@ platforms:
     platform: qemu-arm-virt
     has_simulation: true
     march: armv8a # Cortex-A53 is emulated by default
+    subgroup: 1
     no_hw_test: true
     no_hw_build: true
     microkit_no_hw_test: true
@@ -189,6 +194,7 @@ platforms:
     platform: imx8mq-evk
     req: [imx8mq]
     march: armv8a
+    subgroup: 2
 
   MAAXBOARD:
     arch: arm
@@ -198,6 +204,7 @@ platforms:
     platform: maaxboard
     req: [maaxboard1]
     march: armv8a
+    subgroup: 1
     no_hw_build: true
     # The MaaxBoard in machine queue expects a binary image
     # settings:
@@ -211,6 +218,7 @@ platforms:
     platform: imx8mm-evk
     req: [imx8mm]
     march: armv8a
+    subgroup: 2
 
   IMX8MP_EVK:
     arch: arm
@@ -219,6 +227,7 @@ platforms:
     platform: imx8mp-evk
     req: []
     march: armv8a
+    subgroup: 1
     # there is no board in the machine queue at the moment.
     no_hw_test: true
     microkit_no_hw_test: true
@@ -231,6 +240,7 @@ platforms:
     platform: imx8mp-iotgate
     req: [iotgate1, iotgate3, iotgate4, iotgate5]
     march: armv8a
+    subgroup: 2
     # microkit only, no seL4
     no_hw_build: true
     no_hw_test: true
@@ -244,6 +254,7 @@ platforms:
     platform: tqma8xqp1gb
     req: [tqma]
     march: armv8a
+    subgroup: 5
 
   IMX93:
     arch: arm
@@ -252,6 +263,7 @@ platforms:
     aarch_hyp: [64]
     platform: imx93
     march: armv8a
+    subgroup: 4
     req: [imx93a,imx93b]
     settings:
       # override the default of 4 for sel4test; ignored in non-SMP builds
@@ -279,6 +291,7 @@ platforms:
     platform: odroidc2
     req: [odroidc2]
     march: armv8a
+    subgroup: 4
     microkit_boards: [odroidc2]
 
   ODROID_C4:
@@ -289,6 +302,7 @@ platforms:
     platform: odroidc4
     req: [odroidc4_1, odroidc4_2]
     march: armv8a
+    subgroup: 5
     microkit_boards: [odroidc4]
 
   ODROID_XU:
@@ -329,6 +343,7 @@ platforms:
     platform: zynqmp
     req: [zcu102_2]
     march: armv8a
+    subgroup: 2
     microkit_boards: [zcu102]
     # The ZCU102 in machine queue expects a binary image
     # settings:
@@ -341,6 +356,7 @@ platforms:
     aarch_hyp: [64]
     platform: zynqmp
     march: armv8a
+    subgroup: 3
     # not in seL4 tooling
     no_hw_build: true
     # We don't have any of these physical boards to test against
@@ -352,6 +368,7 @@ platforms:
     aarch_hyp: [64]
     platform: zynqmp
     march: armv8a
+    subgroup: 3
     # not in seL4 tooling
     no_hw_build: true
     # We don't have any of these physical boards to test against
@@ -365,6 +382,7 @@ platforms:
     platform: zynqmp
     req: [zcu106]
     march: armv8a
+    subgroup: 3
 
   STM32MP2:
     arch: arm
@@ -374,6 +392,7 @@ platforms:
     platform: stm32mp2
     req: [stm32mp]
     march: armv8a
+    subgroup: 5
     # FIXME: the watchdog timer fires during the test which
     #        prevents it from completing.
     # @bruelc from STM32 has said that he is going to implement
@@ -397,6 +416,7 @@ platforms:
     req: [rpi3]
     image_platform: bcm2837
     march: armv8a # ARMv8 platform currently used in AARCH32 mode only.
+    subgroup: 2
     no_hw_test: true
 
   RPI4:
@@ -407,6 +427,7 @@ platforms:
     req: [pi4B]
     image_platform: bcm2711
     march: armv8a
+    subgroup: 3
     no_hw_test: true
     microkit_boards: [rpi4b_1gb, rpi4b_2gb, rpi4b_4gb]
 
@@ -423,6 +444,7 @@ platforms:
     req: []
     image_platform: bcm2711
     march: armv8a
+    subgroup: 4
     # microkit-only
     no_hw_build: true
     # cannot be tested
@@ -437,6 +459,7 @@ platforms:
     platform: tx1
     req: [tx1a]
     march: armv8a
+    subgroup: 4
 
   TX2:
     arch: arm
@@ -446,6 +469,7 @@ platforms:
     platform: tx2
     req: [tx2a]
     march: armv8a
+    subgroup: 1
 
   PC99:
     arch: x86

--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -271,7 +271,7 @@ platforms:
     platform: am335x-boneblack
     image_platform: am335x
     req: [bboneblack]
-    march: armv8a
+    march: armv7a
 
   ODROID_C2:
     arch: arm

--- a/sel4test-hw-matrix/README.md
+++ b/sel4test-hw-matrix/README.md
@@ -4,10 +4,16 @@
      SPDX-License-Identifier: CC-BY-SA-4.0
 -->
 
-# seL4Test Hardware Run Matrix
+# seL4Test Hardware Matrix
 
-This action generates a GitHub build matrix for the [sel4test-hw-run] action from
-the hardware platforms listed as available in [platforms.yml][] in this repo.
+This action generates a GitHub matrix for sel4test hardware builds and runs
+from the hardware platforms listed as available in [platforms.yml][] in this
+repo.
+
+Depending on the input parameter `matrix`, it generates either:
+
+- a *run* matrix (default) for the [sel4test-hw-run] action, or
+- a *build* matrix for the [sel4test-hw] action
 
 [platforms.yml]: ../seL4-platforms/platforms.yml
 [sel4test-hw-run]: ../sel4test-hw-run/README.md
@@ -31,4 +37,5 @@ The main test driver is [build.py] in this directory, also shared with the
 
 ## Arguments
 
-This action has no input arguments.
+- `matrix`: which matrix to generate, either `run` (default) for the hardware
+  run matrix, or `build` for the build matrix.

--- a/sel4test-hw-matrix/action.yml
+++ b/sel4test-hw-matrix/action.yml
@@ -2,11 +2,15 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-name: 'seL4Test/Hardware Run Matrix'
-description: Generates matrix for hardware runs.
+name: 'seL4Test/Hardware Matrix'
+description: Generates a matrix for hardware builds or runs.
 author: Gerwin Klein <gerwin.klein@proofcraft.systems>
 
 inputs:
+  matrix:
+    description: 'which matrix to generate: "run" (default) for hardware runs, "build" for builds'
+    required: false
+    default: 'run'
   action_name:
     description: 'internal -- do not use'
     required: false

--- a/sel4test-hw-matrix/steps.sh
+++ b/sel4test-hw-matrix/steps.sh
@@ -17,5 +17,9 @@ pip3 install "junitparser==3.*" sel4-deps
 export PYTHONPATH="${ACTION_DIR}/seL4-platforms"
 echo "::endgroup::"
 
-# start test
-python3 "${ACTION_DIR}/${INPUT_ACTION_NAME}/build.py" --matrix
+case "${INPUT_MATRIX}" in
+  build) MATRIX_ARG="--build-matrix" ;;
+  *)     MATRIX_ARG="--matrix" ;;
+esac
+
+python3 "${ACTION_DIR}/${INPUT_ACTION_NAME}/build.py" "${MATRIX_ARG}"

--- a/sel4test-hw/action.yml
+++ b/sel4test-hw/action.yml
@@ -20,6 +20,9 @@ inputs:
   compiler:
     description: One of `{gcc, clang} to filter test configs on`
     required: false
+  subgroup:
+    description: Comma separated list of build subgroups to filter test configs on.
+    required: false
   debug:
     description: |
       Comma separated list of debug levels from `{debug, release, verification}`

--- a/sel4test-hw/build.py
+++ b/sel4test-hw/build.py
@@ -126,7 +126,7 @@ def build_filter(build: Build) -> bool:
 
 
 def to_json(builds: List[Build]) -> str:
-    """Return a GitHub build matrix per enabled hardware platform as GitHub output assignment."""
+    """Return a GitHub run matrix per enabled hardware platform as GitHub output assignment."""
 
     def run_for_plat(plat: Platform) -> List[dict]:
         if plat.no_hw_test or plat.no_hw_build:
@@ -160,6 +160,15 @@ def to_json(builds: List[Build]) -> str:
     return "matrix=" + json.dumps(matrix)
 
 
+def to_build_json(builds: List[Build]) -> str:
+    """Return a GitHub build matrix over the hardware builds as GitHub output assignment."""
+
+    marches = sorted({b.get_platform().march for b in builds if b.get_platform().march})
+    matrix = {"march": marches, "compiler": ["gcc", "clang"]}
+
+    return "matrix=" + json.dumps(matrix)
+
+
 # If called as main, run all builds from builds.yml
 if __name__ == '__main__':
     builds = load_builds(os.path.dirname(__file__) + "/builds.yml", filter_fun=build_filter)
@@ -170,6 +179,10 @@ if __name__ == '__main__':
 
     if len(sys.argv) > 1 and sys.argv[1] == '--matrix':
         gh_output(to_json(builds))
+        sys.exit(0)
+
+    if len(sys.argv) > 1 and sys.argv[1] == '--build-matrix':
+        gh_output(to_build_json(builds))
         sys.exit(0)
 
     if len(sys.argv) > 1 and sys.argv[1] == '--hw':

--- a/sel4test-hw/build.py
+++ b/sel4test-hw/build.py
@@ -132,27 +132,32 @@ def to_json(builds: List[Build]) -> str:
         if plat.no_hw_test or plat.no_hw_build:
             return []
 
-        # separate runs for each compiler on arm
-        if plat.arch == 'arm':
-            return [
-                {"platform": plat.name, "march": plat.march, "compiler": "gcc"},
-                {"platform": plat.name, "march": plat.march, "compiler": "clang"},
-            ]
+        runs = []
 
-        if plat.arch == 'riscv':
-            return [
+        # separate runs for each compiler on arm and riscv
+        if plat.arch in ['arm', 'riscv']:
+            runs = [
                 {"platform": plat.name, "march": plat.march, "compiler": "gcc"},
                 {"platform": plat.name, "march": plat.march, "compiler": "clang"},
             ]
 
         # separate runs for each compiler + mode on x86, because we have more machines available
         if plat.arch == 'x86':
-            return [
+            runs = [
                 {"platform": plat.name, "march": plat.march, "compiler": "gcc", "mode": 32},
                 {"platform": plat.name, "march": plat.march, "compiler": "clang", "mode": 32},
                 {"platform": plat.name, "march": plat.march, "compiler": "gcc", "mode": 64},
                 {"platform": plat.name, "march": plat.march, "compiler": "clang", "mode": 64},
             ]
+
+        # Add subgroup to the matrix, because build image names have subgroup postfix.
+        # Since subgroup will be the same for all runs of one platform, this provides
+        # info only and does not generate additional jobs.
+        if plat.subgroup is not None:
+            for run in runs:
+                run["subgroup"] = plat.subgroup
+
+        return runs
 
     platforms = set([b.get_platform() for b in builds])
     matrix = {"include": [run for plat in platforms for run in run_for_plat(plat)]}
@@ -163,8 +168,26 @@ def to_json(builds: List[Build]) -> str:
 def to_build_json(builds: List[Build]) -> str:
     """Return a GitHub build matrix over the hardware builds as GitHub output assignment."""
 
-    marches = sorted({b.get_platform().march for b in builds if b.get_platform().march})
-    matrix = {"march": marches, "compiler": ["gcc", "clang"]}
+    compilers = ["gcc", "clang"]
+
+    march_subgroups = {}
+    for b in builds:
+        plat = b.get_platform()
+        march_subgroups.setdefault(plat.march, set()).add(plat.subgroup)
+
+    include = []
+    for march in sorted(march_subgroups):
+        subgroups = sorted(march_subgroups[march])
+        if None in subgroups and len(subgroups) > 1:
+            raise ValueError(f"march {march} mixes subgrouped and ungrouped platforms")
+        for compiler in compilers:
+            if subgroups == [None]:
+                include.append({"march": march, "compiler": compiler})
+            else:
+                for sg in subgroups:
+                    include.append({"march": march, "compiler": compiler, "subgroup": sg})
+
+    matrix = {"include": include}
 
     return "matrix=" + json.dumps(matrix)
 


### PR DESCRIPTION
- add subgroups to the "march" build groups so we can parallelise specific groups independently
- use these for armv8a in sel4test-hw
- generate build matrix in python, so the subgroups get picked up automatically and don't have to be repeated

This speeds up the overall sel4test-hw build from over 50min to about 13min, which is the slowest riscv build. armv8 builds now finish just before riscv at about 12:30min. 

After this is merged, we still need to update the deployment workflow file in the seL4 repo, but the hw-test and hw-build PR checks should already benefit automatically.