### PR TITLE
sel4bench-metrics: install libxml-utils

### DIFF
--- a/sel4bench-metrics/steps.sh
+++ b/sel4bench-metrics/steps.sh
@@ -26,8 +26,8 @@ chmod a+x "${BINDIR}/repo"
 
 PATH="${BINDIR}":$PATH
 
+sudo apt-get install -y --no-install-recommends libffi-dev libxml2-utils
 # python env
-sudo apt-get install -y --no-install-recommends libffi-dev
 . ${SCRIPTS}/setup-python-venv.sh
 pip3 install "junitparser==3.*" sel4-deps
 export PYTHONPATH="${ACTION_DIR}/seL4-platforms"


### PR DESCRIPTION
Install libxml-utils for xmllint tool.

This is what prevented CI from finding sha_kernel and sha_bench, even though I could swear that I've seen this working in the test.