### PR TITLE
sel4bench: more robust json result extraction

### DIFF
--- a/sel4bench/build.py
+++ b/sel4bench/build.py
@@ -51,9 +51,11 @@ def hw_build(manifest_dir: str, build: Build):
 def extract_json(results: str, run: Run) -> int:
     """Process test logs to extract JSON results."""
 
+    # Only extract the first JSON OUTPUT block. In rare cases (mq failure to
+    # detect boot completion), there can be two, and both are valid results.
     res = subprocess.run(
         f"cat {results} | "
-        f"sed -e '/JSON OUTPUT/,/END JSON OUTPUT/!d' | "
+        f"sed -n '/JSON OUTPUT/,/END JSON OUTPUT/p; /END JSON OUTPUT/q' | "
         f"sed 's/END JSON OUTPUT//' | sed 's/JSON OUTPUT//' | jq '.' "
         f" > ../{run.name}.json",
         shell=True


### PR DESCRIPTION
Only extract the first "JSON OUTPUT" block in stdout.

It is possible for there to be more than one when the mq scripts fail to detect that the machine has booted correctly, the tests completes, boot detection times out, and another full test completes. In that case, there is no test failure and both results are valid.

This is generally rare, but it does happen every once in a while, recently on skylake twice, and there is no reason not to just use the result. It'd be nicer to make sure the boot detection is solid everywhere, but I don't want to dive into those scripts.