### PR TITLE
sel4bench: scale hw-run timeout by iterations

### DIFF
--- a/.github/workflows/sel4bench-hw.yml
+++ b/.github/workflows/sel4bench-hw.yml
@@ -129,6 +129,7 @@ jobs:
           platform: ${{ matrix.platform }}
           req: ${{ matrix.req }}
           index: ${{ strategy.job-index }}
+          iterations: ${{ inputs.iterations }}
         env:
           HW_SSH: ${{ secrets.HW_SSH }}
       - name: Upload results

--- a/sel4bench-hw/README.md
+++ b/sel4bench-hw/README.md
@@ -41,6 +41,7 @@ use one or more of the following:
 - `mode`: one of `{32, 64}`
 - `platform`: platform name, e.g. `pc99`
 - `req`: machine name, e.g. `haswell3`
+- `iterations`: number of benchmark iterations, for scaling job timeout
 
 ## Example
 

--- a/sel4bench-hw/action.yml
+++ b/sel4bench-hw/action.yml
@@ -26,6 +26,9 @@ inputs:
   index:
     description: job index in matrix build
     required: true
+  iterations:
+    description: Number of benchmark iterations, for scaling job timeout.
+    required: false
   action_name:
     description: 'internal -- do not use'
     required: false

--- a/sel4bench/build.py
+++ b/sel4bench/build.py
@@ -33,6 +33,10 @@ def adjust_build_settings(build: Build):
     if iterations:
         build.settings['ITERATIONS'] = iterations
 
+    if build.settings['ITERATIONS']:
+        scale = max(1, float(build.settings['ITERATIONS']) * 0.75)
+        build.timeout = round(build.timeout * scale)
+
     # see discussion on https://github.com/seL4/sel4bench/pull/20 for hifive exclusion
     if build.is_smp() or build.get_platform().name == 'HIFIVE':
         build.settings['HARDWARE'] = 'FALSE'
@@ -81,6 +85,8 @@ def hw_run(manifest_dir: str, run: Run):
     if run.build.is_disabled():
         print(f"Run {run.name} disabled, skipping.")
         return SKIP
+
+    adjust_build_settings(run.build)
 
     tries = 3
     results = 'results.txt'


### PR DESCRIPTION
Scale the hardware run timeout by 0.75 * iterations.

The current single-iteration timeout contains board boot time + about 2 * estimated benchmark run time, so scaling by 0.75 should be more than enough.

(The slowest benchmark config `PC99_SMP_64_haswell3 ` seems to be failing on legitimate timeouts sometimes with 5 iterations.)
