### PR TITLE
platforms: keep timestamps for command stdout

### DIFF
--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -24,6 +24,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 
 # exported names:
 __all__ = [
@@ -439,8 +440,10 @@ def run_cmd(cmd, run: Union[Run, Build], prev_output: Optional[str] = None) -> i
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=sys.stderr, bufsize=0)
         lines = []
         for line in process.stdout:
-            lines.append(line.decode().rstrip())
-            sys.stdout.buffer.write(line)
+            ts = time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime())
+            decoded = line.decode().rstrip()
+            lines.append(f"[{ts}] " + decoded)
+            sys.stdout.buffer.write(decoded)   # print without timestamp
             sys.stdout.flush()
             sys.stderr.flush()
         ret = process.wait()


### PR DESCRIPTION
Add timestamps for the in-memory stdout record of commands, but do not print them, because GitHub does its own log time stamping.

Instead, keep them for summaries and failure detection later.

This should now print time stamps in the details section of the summary.