### PR TITLE
platforms: detect and summarise common failures 

### DIFF
--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -604,6 +604,8 @@ infra_failure_markers = [
 # component is the cause name in the summary. Earlier markers are matched first.
 sel4_failure_markers = [
     ("seL4 failed assertion", "Kernel assertion"),
+    ("Debug halt syscall from user thread", "Debug halt"),
+    ("Kernel entry via Unknown syscall", "Kernel entry via unknown syscall"),
 ]
 
 # Generic mq.sh completion-timeout marker. When this is present we will attempt

--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -29,7 +29,8 @@ import time
 # exported names:
 __all__ = [
     "Build", "load_builds", "run_builds", "run_build_script", "junit_results", "sanitise_junit",
-    "sim_script", "Step", "default_analysis", "Analysis"
+    "sim_script", "Step", "Analysis", "default_analysis", "ssh_repeat_analysis", "infra_analysis",
+    "seL4_analysis"
 ]
 
 # where to expect jUnit results by default
@@ -231,8 +232,8 @@ class Build:
         return self.get_platform().getISA(self.get_mode())
 
     # create a Run on the fly if we only want one Run per Build
-    def hw_run(self, log):
-        return Run(self).hw_run(log)
+    def hw_run(self, log, analyse=None):
+        return Run(self).hw_run(log, analyse)
 
 
 class Run:
@@ -251,7 +252,9 @@ class Run:
     def get_req(self) -> List[str]:
         return self.req or self.build.get_req()
 
-    def hw_run(self, log):
+    def hw_run(self, log, analyse=None):
+        """Return (script, final_script) for a hardware test run and optional
+           analysis function (default sel4_analysis)."""
         build = self.build
 
         if build.is_disabled():
@@ -276,7 +279,8 @@ class Run:
                    lock_held=True,
                    key=job_key(),
                    log=log,
-                   error_str=build.error)
+                   error_str=build.error,
+                   analyse=analyse)
         ], [
             mq_release(machine)
         ]
@@ -339,11 +343,13 @@ def mq_run(success_str: str,
            lock_held=False,
            keep_alive=False,
            key: Optional[str] = None,
-           error_str: Optional[str] = None):
+           error_str: Optional[str] = None,
+           analyse: Optional['Analysis'] = None):
     """Machine queue mq.sh run command with arguments.
 
        Expects success marker, machine name, and boot image file(s).
-       See output of mq.sh run for details on optional parameters."""
+       See output of mq.sh run for details on optional parameters.
+       Takes optional output analysis function (default sel4_analysis)."""
 
     command = ['time', 'mq.sh', 'run',
                '-c', success_str,
@@ -365,7 +371,7 @@ def mq_run(success_str: str,
     for f in files:
         command.extend(['-f', f])
 
-    return Step(command, analyse=ssh_repeat_analysis)
+    return Step(command, analyse=analyse or seL4_analysis)
 
 
 def mq_lock(machine: str):
@@ -396,9 +402,6 @@ FAILURE = 0
 SUCCESS = 1
 SKIP = 2
 REPEAT = 3
-
-# string for detecting ssh failure
-ssh_failure_str = "Unable to ssh to tftp.keg.cse.unsw.edu.au"
 
 
 def success_from_bool(success: bool) -> int:
@@ -581,15 +584,135 @@ def default_analysis(run, result, output):
     return result, output
 
 
+# Transient ssh problems where the test should be repeated.
+ssh_failure_markers = [
+    "Unable to ssh to tftp.keg.cse.unsw.edu.au",
+]
+
+
+# Infrastructure problems visible in log output, with cause name.
+# Usually not recoverable or already repeated. Earlier markers are matched first.
+infra_failure_markers = [
+    ("Connection closed by UNKNOWN port 65535", "ssh failure"),
+    ("[-- Console server shutting down --]", "console"),
+    ("Unable to connect to 10.13.1", "console"),
+    ("console is down", "console"),
+    ("[[Boot timeout]]", "boot failure"),
+]
+
+# kernel failure markers that are not standard junit test failures. Second
+# component is the cause name in the summary. Earlier markers are matched first.
+sel4_failure_markers = [
+    ("seL4 failed assertion", "Kernel assertion"),
+]
+
+# Generic mq.sh completion-timeout marker. When this is present we will attempt
+# to further classify.
+timeout_marker = "[[Timeout]]"
+
+# Console output detecting elfloader or seL4 is running. If none of these are
+# present, a timeout is a board boot problem.
+sel4_running_markers = [
+    # elfloader output
+    "Jumping to kernel-image entry point",
+    "Enabling MMU and paging",
+    # kernel output
+    "Bootstrapping kernel",
+    "reserved virt address space regions",
+    # common user space output
+    "Booting all finished, dropped to user space",
+    "Starting test suite",
+    "Running test",
+    "</testcase>",
+]
+
+
+def find_marker(output: Optional[List[str]], markers: List[str]) -> Optional[str]:
+    """Return the first output line containing any of the markers, else None."""
+    for line in output or []:
+        if any(marker in line for marker in markers):
+            return line
+    return None
+
+
+def output_around(output: List[str], marker: str, before: int = 15, after: int = 5) -> str:
+    """Return output centred on the line containing `marker` (-before, +after).
+       `marker` must occur in `output`."""
+    idx = next(i for i, line in enumerate(output) if marker in line)
+    return "\n".join(output[max(0, idx - before): idx + after + 1])
+
+
+def repeat_on_markers(result, output, markers: List[str], what: str) \
+        -> Optional[Tuple[int, Optional[List[str]]]]:
+    """Repeat if marker was found."""
+    if result == FAILURE:
+        marker = find_marker(output, markers)
+        if marker:
+            printc(ANSI_YELLOW, f"Detected {what}, repeating test:\n  {marker}")
+            return REPEAT, output
+    return None
+
+
 ssh_repeat_analysis: Analysis
 
 
 def ssh_repeat_analysis(run, result, output):
-    """Analysis for mq commands: on ssh connection failure, repeat the whole test;
-       otherwise fall back to `default_analysis`."""
-    if result == FAILURE and any(ssh_failure_str in line for line in output):
-        printc(ANSI_YELLOW, "Detected ssh failure, trying to repeat test.")
-        return REPEAT, output
+    """Repeat whole test on ssh failure, otherwise fall back to `default_analysis`."""
+    return (repeat_on_markers(result, output, ssh_failure_markers, "ssh failure")
+            or default_analysis(run, result, output))
+
+
+infra_analysis: Analysis
+
+
+def infra_analysis(run, result, output):
+    """Infrastructure analysis: repeat on ssh failure, otherwise detect infrastructure
+       failure and fail; falls back on default_analysis."""
+    return (repeat_on_markers(result, output, ssh_failure_markers, "ssh failure")
+            or infra_cause(run, result, output)
+            or default_analysis(run, result, output))
+
+
+def record_cause(run, cause: str, output, marker: str) -> Tuple[int, Optional[List[str]]]:
+    """Record a test summary failure cause with the output around `marker`; return FAILURE."""
+    record_summary(TestSummary(
+        name=run.name,
+        causes=[(cause, output_around(output, marker))]))
+    return FAILURE, output
+
+
+def infra_cause(run, result, output) -> Optional[Tuple[int, Optional[List[str]]]]:
+    """Detect and show cause for infrastructure failures in summary.
+       Return FAILURE if a failure was found, else None."""
+    if result == FAILURE:
+        marker = find_marker(output, [m for m, _ in infra_failure_markers])
+        if marker:
+            cause = next(c for m, c in infra_failure_markers if m in marker)
+            return record_cause(run, cause, output, marker)
+    return None
+
+
+seL4_analysis: Analysis
+
+
+def seL4_analysis(run, result, output):
+    """Repeat on transient ssh failures; record cause for infrastructure and
+       kernel failures; otherwise fall back to default_analysis."""
+    repeat = repeat_on_markers(result, output, ssh_failure_markers, "ssh failure")
+    if repeat:
+        return repeat
+    if result == FAILURE:
+        infra = infra_cause(run, result, output)
+        if infra:
+            return infra
+        marker = find_marker(output, [m for m, _ in sel4_failure_markers])
+        if marker:
+            cause = next(name for m, name in sel4_failure_markers if m in marker)
+            return record_cause(run, cause, output, marker)
+        timeout = find_marker(output, [timeout_marker])
+        if timeout:
+            cause = "Test timeout" if find_marker(output, sel4_running_markers) else "Boot timeout"
+            return record_cause(run, cause, output, timeout)
     return default_analysis(run, result, output)
 
 

--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -365,12 +365,13 @@ def mq_run(success_str: str,
     for f in files:
         command.extend(['-f', f])
 
-    return wrap_ssh_failure(command)
+    return Step(command, analyse=ssh_repeat_analysis)
 
 
 def mq_lock(machine: str):
     """Get lock for a machine. Allow lock to be reclaimed after 30min."""
-    return wrap_ssh_failure(['time', 'mq.sh', 'sem', '-wait', machine, '-k', job_key(), '-T', '1800'])
+    return Step(['time', 'mq.sh', 'sem', '-wait', machine, '-k', job_key(), '-T', '1800'],
+                analyse=ssh_repeat_analysis)
 
 
 def mq_release(machine: str) -> List[str]:
@@ -387,7 +388,7 @@ def mq_cancel(machine: str) -> List[str]:
 
 def mq_print_lock(machine: str):
     """Print lock status for machine."""
-    return wrap_ssh_failure(['mq.sh', 'sem', '-info', machine])
+    return Step(['mq.sh', 'sem', '-info', machine], analyse=ssh_repeat_analysis)
 
 
 # return codes for a test run or single step of a run
@@ -398,20 +399,6 @@ REPEAT = 3
 
 # string for detecting ssh failure
 ssh_failure_str = "Unable to ssh to tftp.keg.cse.unsw.edu.au"
-
-
-def wrap_ssh_failure(cmd: List[str]):
-    """Wrap a list of commands in a check for failing to connect via ssh.
-    Signal test repeat instead of failure in that case
-    """
-    def wrapped_cmd(run, prev_output):
-        result, output = run_cmd(cmd, run, prev_output)
-        if result == FAILURE:
-            if any(ssh_failure_str in line for line in output):
-                printc(ANSI_YELLOW, "Detected ssh failure, trying to repeat test.")
-                return REPEAT, output
-        return result, output
-    return wrapped_cmd
 
 
 def success_from_bool(success: bool) -> int:
@@ -592,6 +579,18 @@ def default_analysis(run, result, output):
             name=run.name,
             causes=[("Incomplete", "\n".join(output[-20:]))]))
     return result, output
+
+
+ssh_repeat_analysis: Analysis
+
+
+def ssh_repeat_analysis(run, result, output):
+    """Analysis for mq commands: on ssh connection failure, repeat the whole test;
+       otherwise fall back to `default_analysis`."""
+    if result == FAILURE and any(ssh_failure_str in line for line in output):
+        printc(ANSI_YELLOW, "Detected ssh failure, trying to repeat test.")
+        return REPEAT, output
+    return default_analysis(run, result, output)
 
 
 def run_build_script(manifest_dir: str,

--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -605,7 +605,13 @@ infra_failure_markers = [
 sel4_failure_markers = [
     ("seL4 failed assertion", "Kernel assertion"),
     ("Debug halt syscall from user thread", "Debug halt"),
-    ("Kernel entry via Unknown syscall", "Kernel entry via unknown syscall"),
+    ("Kernel entry via Unknown", "Unknown kernel entry"),
+    ("KERNEL DATA ABORT!", "Kernel data abort"),
+    ("KERNEL PREFETCH ABORT!", "Kernel prefetch abort"),
+    ("KERNEL UNDEFINED INSTRUCTION!", "Kernel undefined instruction"),
+    ("KERNEL EXCEPTION", "Kernel exception"),
+    ("KERNEL ABORT", "Kernel abort"),
+    ("halting...", "Kernel halt"),
 ]
 
 # Generic mq.sh completion-timeout marker. When this is present we will attempt
@@ -621,6 +627,10 @@ sel4_running_markers = [
     # kernel output
     "Bootstrapping kernel",
     "reserved virt address space regions",
+    # microkit
+    "LDR|INFO: loader for seL4 starting",
+    "LDR|INFO|CPU0: jumping to kernel",
+    "MON|INFO: Microkit Monitor started!",
     # common user space output
     "Booting all finished, dropped to user space",
     "Starting test suite",

--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -14,7 +14,7 @@ them, `run_build_script` for a standard test driver frame, and
 
 from platforms import ValidationException, Platform, platforms, load_yaml, mcs_unsupported
 
-from typing import Optional, List, Tuple, Union
+from typing import Callable, Optional, List, Tuple, Union
 from junitparser import JUnitXml
 from dataclasses import dataclass, field
 
@@ -29,7 +29,7 @@ import time
 # exported names:
 __all__ = [
     "Build", "load_builds", "run_builds", "run_build_script", "junit_results", "sanitise_junit",
-    "sim_script"
+    "sim_script", "Step", "default_analysis", "Analysis"
 ]
 
 # where to expect jUnit results by default
@@ -562,6 +562,38 @@ def sim_script(success: str, failure=None, timeout=1200):
     ]
 
 
+# Analysis function that gets result and output of a single script step. Can
+# return a new result (e.g. FAILURE -> REPEAT) and/or record a test summary.
+# Should pass on output.
+Analysis = Callable[[Union[Run, Build], int, List[str]], Tuple[int, List[str]]]
+
+
+@dataclass
+class Step:
+    """A script step: command plus optional output analysis."""
+
+    #  list of command-line arguments or callable (see `run_cmd`)
+    command: Union[list, Callable]
+    analyse: Optional[Analysis] = None
+
+
+def as_step(line) -> Step:
+    """Accept command line, Callable, or Step. Return a Step."""
+    return line if isinstance(line, Step) else Step(line)
+
+
+default_analysis: Analysis
+
+
+def default_analysis(run, result, output):
+    """Default step analysis: record an `Incomplete` summary on failure"""
+    if result == FAILURE:
+        record_summary(TestSummary(
+            name=run.name,
+            causes=[("Incomplete", "\n".join(output[-20:]))]))
+    return result, output
+
+
 def run_build_script(manifest_dir: str,
                      run: Union[Run, Build],
                      script,
@@ -607,22 +639,24 @@ def run_build_script(manifest_dir: str,
         result = SUCCESS
         output = None
         for line in script:
-            result, output = run_cmd(line, run, output)
+            step = as_step(line)
+            result, output = run_cmd(step.command, run, output)
+            result, output = (step.analyse or default_analysis)(run, result, output)
             if result != SUCCESS:
                 break
-
         if result == FAILURE:
             printc(ANSI_RED, ">>> command failed, aborting.")
-            record_summary(TestSummary(
-                name=run.name,
-                causes=[("Incomplete", "\n".join(output[-20:]))]))
         elif result == SKIP:
             printc(ANSI_YELLOW, ">>> skipping this test.")
 
         # run final script tasks even in case of failure, but not for SKIP
         if result != SKIP:
             for line in final_script:
-                r, output = run_cmd(line, run, output)
+                step = as_step(line)
+                r, output = run_cmd(step.command, run, output)
+                # Skip default analysis for final scripts, but run analysis if explicitly provided.
+                if step.analyse:
+                    r, output = step.analyse(run, r, output)
                 if r == FAILURE:
                     # If a final script task fails, the overall task fails unless
                     # we have already decided to repeat. In either case we stop

--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -624,6 +624,8 @@ sel4_running_markers = [
     # elfloader output
     "Jumping to kernel-image entry point",
     "Enabling MMU and paging",
+    "Enabling hypervisor MMU and jumping to entry point...",
+    "Enabling MMU and jumping to entry point...",
     # kernel output
     "Bootstrapping kernel",
     "reserved virt address space regions",


### PR DESCRIPTION
Detect infrastructure failure causes and seL4 crash failures and report them in the GitHub summary. Try to distinguish board boot failures from test hangs.

Builds on @midnightveil's work in https://github.com/midnightveil/seL4_logs

To get there, first:
-  refactor scripts for analysis steps
-  use analysis for repeat on ssh failure

We can probably go further than this with automatically analysing failures, but this is a good first step.