### PR TITLE
platforms: re-add zcu102

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -341,14 +341,10 @@ platforms:
     smp: [64]
     aarch_hyp: [64]
     platform: zynqmp
-    req: [zcu102_2]
+    req: [zcu102, zcu102_2]
     march: armv8a
     subgroup: 2
     microkit_boards: [zcu102]
-    # The ZCU102 in machine queue expects a binary image
-    # settings:
-    # Sel4testAllowSettingsOverride: true
-    # ElfloaderImage: "binary"
 
   KRIA_K26:
     arch: arm


### PR DESCRIPTION
Peter fixed the zcu102 setup and it is now booting fine again. Re-add to sel4test.

Also remove old commented out settings.