### PR TITLE
platforms: add RPI5 hardware builds

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -447,6 +447,17 @@ platforms:
     microkit_no_hw_test: true
     microkit_boards: [rpi4b_8gb]
 
+  RPI5:
+    arch: arm
+    modes: [64]
+    platform: rpi5
+    req: []
+    image_platform: bcm2712
+    march: armv8a
+    subgroup: 5
+    # the seL4 foundation has no RPI5 hardware
+    no_hw_test: true
+
   TX1:
     arch: arm
     modes: [64]


### PR DESCRIPTION
So that this is at least built in CI, even if it is not tested on real hardware.

Related: https://github.com/seL4/seL4/pull/1515