### PR TITLE
platforms: fix RPI5 cmake platform

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -450,7 +450,7 @@ platforms:
   RPI5:
     arch: arm
     modes: [64]
-    platform: rpi5
+    platform: bcm2712
     req: []
     image_platform: bcm2712
     march: armv8a


### PR DESCRIPTION
It's actually BCM2712, not RPI5.