### PR TITLE
platforms/builds: fix exception printing

### DIFF
--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -814,7 +814,7 @@ def run_build_script(manifest_dir: str,
                 result = FAILURE
             except Exception as e:
                 printc(ANSI_RED, f"Error parsing {junit_file}")
-                print("Exception: " + e)
+                print(f"Exception: {e}")
                 result = FAILURE
 
         if result == REPEAT and tries_left > 0:


### PR DESCRIPTION
The "+ e" is a type error, "{e}" should print using `__str__`.