### PR TITLE
Revert "checkout: sync --tags too"

### DIFF
--- a/scripts/checkout-manifest.sh
+++ b/scripts/checkout-manifest.sh
@@ -46,5 +46,5 @@ fi
 
 if [ -z "${REPO_NO_SYNC}" ]
 then
-  $REPO sync -j 4 --tags
+  $REPO sync -j 4
 fi


### PR DESCRIPTION
This reverts commit f63876c415aafcb98bebe40fbcb7b753a59d619f.

This feature of Git Repo seems somewhat broken. In the case where depth is 0, tags are fetched already by default. In the case where depth is non-zero, Repo forcibly ignores the tags flag and passes --no-tags by default.

Microkit has ended up adding an additional step after this checkout to fetch the tags. https://github.com/seL4/microkit/pull/546