### PR TITLE
platforms/builds: add seL4bench banner

### DIFF
--- a/seL4-platforms/builds.py
+++ b/seL4-platforms/builds.py
@@ -639,6 +639,7 @@ sel4_running_markers = [
     "Starting test suite",
     "Running test",
     "</testcase>",
+    "se\033[32mL4\033[37m Benchmark",
 ]
 
 


### PR DESCRIPTION
Since sel4bench doesn't run in debug mode, it misses all of the other "user level is alive strings".