### PR TITLE
"Test with" for plain git checkouts

### DIFF
--- a/camkes-unit/Dockerfile
+++ b/camkes-unit/Dockerfile
@@ -6,7 +6,9 @@
 
 FROM trustworthysystems/camkes:latest
 
-COPY scripts/*.sh camkes-unit/steps.sh /usr/bin/
+RUN pip3 install --break-system-packages PyGithub
+
+COPY scripts/* camkes-unit/steps.sh /usr/bin/
 
 RUN mkdir /workspace
 WORKDIR /workspace

--- a/camkes-unit/README.md
+++ b/camkes-unit/README.md
@@ -12,7 +12,8 @@ for `capdl`.
 
 ## Arguments
 
-None
+- `token`: GitHub token for read access to the repository. Optional, but
+           improves rate limits.
 
 ## Example
 
@@ -32,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: seL4/ci-actions/camkes-unit@master
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Build

--- a/camkes-unit/action.yml
+++ b/camkes-unit/action.yml
@@ -7,7 +7,10 @@ description: |
   Runs unit tests for the `camkes-tool` repository.
 author: Gerwin Klein <gerwin.klein@proofcraft.systems>
 
-# no inputs
+inputs:
+  token:
+    description: 'GitHub token for read access to repository'
+    required: false
 
 runs:
   using: 'docker'

--- a/camkes-unit/steps.sh
+++ b/camkes-unit/steps.sh
@@ -13,12 +13,22 @@ git clone https://github.com/seL4/capdl
 mkdir camkes-tool
 cd camkes-tool
 checkout.sh
+cd - > /dev/null
+
+if [ "${GITHUB_EVENT_NAME}" = "pull_request_target" ] ||
+   [ "${GITHUB_EVENT_NAME}" = "pull_request" ]
+then
+  export INPUT_EXTRA_REFS="$(get-prs)"
+  export EXTRA_REFS_PATHS="seL4/capdl=capdl"
+  fetch-extra-refs.sh
+fi
 
 echo
 echo "Repo summary:"
-echo "camkes-tool: $(git rev-parse --short HEAD)"
-echo "      capdl: $(git -C ../capdl rev-parse --short HEAD)"
+echo "camkes-tool: $(git -C camkes-tool rev-parse --short HEAD)"
+echo "      capdl: $(git -C capdl rev-parse --short HEAD)"
 
+cd camkes-tool
 export PYTHONPATH=../capdl/python-capdl-tool
 echo "::endgroup::"
 

--- a/scripts/fetch-extra-refs.sh
+++ b/scripts/fetch-extra-refs.sh
@@ -8,6 +8,37 @@
 # Expects INPUT_EXTRA_REFS to be a space separated list of:
 #   org/repo#num  - pull request (fetched from refs/pull/<num>/head)
 #   org/repo@ref  - branch name or commit SHA (fetched as <ref>)
+#
+# If EXTRA_REFS_PATHS is set, assume plain git clones under these paths.
+# Otherwise assume a repo manifest checkout. Specs in EXTRA_REFS_PATHS take
+# precedence if both are present.
+#
+# Expects EXTRA_REFS_PATHS to be unset or a space separated list of:
+#   org/repo=path - path of that repo, relative to the current directory
+
+# Print the path of repo $1 ("org/repo") or nothing if not present.
+repo_dir() {
+  # treat repo names as case-insensitive for comparison, as in repo-util
+  NAME=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+
+  for P in ${EXTRA_REFS_PATHS}
+  do
+    # extract the part before "=" (org/repo), case insensitive
+    KEY=$(echo "${P%=*}" | tr '[:upper:]' '[:lower:]')
+    if [ "${KEY}" = "${NAME}" ]
+    then
+      # return the part after "=" (path)
+      echo "${P#*=}"
+      return
+    fi
+  done
+
+  # fall through to repo-util, we could in theory do both (plain checkout plus manifest)
+  if [ -d .repo ]
+  then
+    repo-util path "$1" 2>/dev/null
+  fi
+}
 
 if [ -z "${INPUT_XML}" ] && [ -n "${INPUT_EXTRA_REFS}" ]
 then
@@ -35,6 +66,13 @@ then
         ;;
     esac
 
+    DIR=$(repo_dir "${REPO}")
+    if [ -z "${DIR}" ]
+    then
+      echo "Skipping ${R}: ${REPO} is not part of this checkout/manifest"
+      continue
+    fi
+
     REPO_PATH="github.com/${REPO}.git"
 
     if [ -n "${INPUT_TOKEN}" ]
@@ -45,7 +83,7 @@ then
       URL="https://${REPO_PATH}"
     fi
 
-    cd $(repo-util path ${REPO})
+    cd "${DIR}"
     echo "Fetching ${REF} from ${REPO_PATH}"
     git fetch -q --depth 1 ${URL} ${FETCH}
     git checkout -q ${CHECKOUT}

--- a/scripts/repo-util
+++ b/scripts/repo-util
@@ -66,7 +66,7 @@ def get_projects() -> dict:
             # lower-case name as key to remain case insensitive; store manifest name as value
             project_dict[repo.lower()] = (path.strip(), repo)
     except:
-        print("Failed to get project list from `repo`")
+        print("Failed to get project list from `repo`", file=sys.stderr)
         project_dict = {}
 
     return project_dict


### PR DESCRIPTION
- Generalise `fetch-extra-refs.sh` so that it can pull branches or PRs for plain git clones that are not part of a repo manifest checkout. Use an env variable `EXTRA_REFS_PATHS` for org/repo to path mapping in that case.

- Make sure `repo-util` has empty stdout when repo manifest is not present.

- Use the new `fetch-extra-refs.sh` abilities to make "Test with:" specs available for camkes-unit tests.

- Add GitHub token input for decreasing rate limits on PR description fetch.

This should make the camkes unit tests work that were failing for the recent ticks/us PR.