### PR TITLE
github: avoid strategy.job-index as key

### DIFF
--- a/.github/workflows/sel4bench-hw.yml
+++ b/.github/workflows/sel4bench-hw.yml
@@ -58,7 +58,7 @@ jobs:
     # To reduce the load on GitHub runner numbers and machine queue we cancel
     # any older runs of this workflow for the current PR.
     concurrency:
-      group: ${{ github.workflow }}-sel4bench-build-pr-${{ github.event.number }}-${{ strategy.job-index }}
+      group: ${{ github.workflow }}-sel4bench-build-pr-${{ github.event.number }}-${{ matrix.march }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     concurrency:
-      group: ${{ github.workflow }}-sel4bench-hw-run-pr-${{ github.event.number }}-${{ strategy.job-index }}
+      group: ${{ github.workflow }}-sel4bench-hw-run-pr-${{ github.event.number }}-${{ matrix.platform }}-${{ matrix.req }}
       cancel-in-progress: true
     strategy:
       fail-fast: false

--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -62,7 +62,7 @@ jobs:
     # To reduce the load (especially on the machine queue) we cancel any older
     # runs of this workflow for the current PR.
     concurrency:
-      group: ${{ github.workflow }}-sel4test-build-pr-${{ github.event.number }}-${{ strategy.job-index }}
+      group: ${{ github.workflow }}-sel4test-build-pr-${{ github.event.number }}-${{ matrix.march }}-${{ matrix.compiler }}-${{ matrix.subgroup }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
@@ -105,7 +105,7 @@ jobs:
                (contains(github.event.pull_request.labels.*.name, 'hw-test') ||
                 github.event.label.name == 'hw-test')) }}
     concurrency:
-      group: ${{ github.workflow }}-sel4test-hw-run-pr-${{ github.event.number }}-${{ strategy.job-index }}
+      group: ${{ github.workflow }}-sel4test-hw-run-pr-${{ github.event.number }}-${{ matrix.platform }}-${{ matrix.compiler }}-${{ matrix.mode }}
       cancel-in-progress: true
     strategy:
       fail-fast: false

--- a/.github/workflows/sel4test-sim.yml
+++ b/.github/workflows/sel4test-sim.yml
@@ -20,7 +20,7 @@ jobs:
         march: [armv7a, armv8a, nehalem, rv32imac, rv64imac]
         compiler: [gcc, clang]
     concurrency:
-      group: ${{ github.workflow }}-sel4sim-pr-${{ github.event.number }}-${{ strategy.job-index }}
+      group: ${{ github.workflow }}-sel4sim-pr-${{ github.event.number }}-${{ matrix.march }}-${{ matrix.compiler }}
       cancel-in-progress: true
     steps:
     - uses: seL4/ci-actions/sel4test-sim@master


### PR DESCRIPTION
Avoid strategy.job-index as concurrency key in pull request concurrency groups, because GitHub can expand the matrix in different orders. Use matrix contents instead.