### PR TITLE
feat: add microkit_no_hw_test and microkit_boards to rpi5 platform

### DIFF
--- a/seL4-platforms/platforms.yml
+++ b/seL4-platforms/platforms.yml
@@ -457,6 +457,9 @@ platforms:
     subgroup: 5
     # the seL4 foundation has no RPI5 hardware
     no_hw_test: true
+    # cannot be tested
+    microkit_no_hw_test: true
+    microkit_boards: [rpi5b_2gb]
 
   TX1:
     arch: arm


### PR DESCRIPTION
Ensure CI doesn't fail with anything regarding the Raspberry Pi 5, from https://github.com/seL4/microkit/pull/573#pullrequestreview-4760188836.